### PR TITLE
Fix AttributeError in Virtual Host Tree with old Hosts

### DIFF
--- a/cmk/gui/plugins/sidebar/virtual_host_tree.py
+++ b/cmk/gui/plugins/sidebar/virtual_host_tree.py
@@ -303,7 +303,7 @@ function virtual_host_tree_enter(path)
 
         state, have_svc_problems = self._calculate_state(state, num_crit, num_unknown, num_warn)
 
-        tags = set(custom_variables.get("TAGS", []).split())
+        tags = set(custom_variables.get("TAGS", "").split())
 
         # Now go through the levels of the tree. Each level may either be
         # - a tag group id, or


### PR DESCRIPTION
When creating a virtual Host tree there is a AttributeError when no TAGS are set. The Source returned a empty list [] and tried to execute the .split() method (not supported by list). 

The empty list is replaced by an empty String, which gets converted to an empty list by .split()

Traceback (most recent call last):
  File "/omd/sites/xxxxxx/lib/python3/cmk/gui/sidebar.py", line 603, in ajax_snapin
    snapin_instance.show()
  File "/omd/sites/xxxxxx/lib/python3/cmk/gui/plugins/sidebar/virtual_host_tree.py", line 79, in show
    self._show_tree()
  File "/omd/sites/xxxxxx/lib/python3/cmk/gui/plugins/sidebar/virtual_host_tree.py", line 103, in _show_tree
    tree = self._compute_tag_tree(tree_spec)
  File "/omd/sites/xxxxxx/lib/python3/cmk/gui/plugins/sidebar/virtual_host_tree.py", line 289, in _compute_tag_tree
    self._add_host_to_tree(tree_spec, tree, host_row, tag_groups, topics)
  File "/omd/sites/xxxxxx/lib/python3/cmk/gui/plugins/sidebar/virtual_host_tree.py", line 306, in _add_host_to_tree
    tags = set(custom_variables.get("TAGS", []).split())
AttributeError: 'list' object has no attribute 'split'

 
This Bug also exists in the 1.6.0 Version.