### PR TITLE
added missing agent version check string

### DIFF
--- a/cmk/core_helpers/agent.py
+++ b/cmk/core_helpers/agent.py
@@ -821,7 +821,7 @@ class AgentSummarizerDefault(AgentSummarizer):
             if agent_version is None:
                 return False
 
-            if agent_version in ["(unknown)", "None"]:
+            if agent_version in ["(unknown)", "None", "unknown"]:
                 return False
 
             if isinstance(expected_version, str) and expected_version != agent_version:


### PR DESCRIPTION
Special Agents with AgentOS output and without version number have a problem with the expected agent version check.
There are two special agents with AgentOS output at the moment (Fritz and VNX).
VNX agent gives the output for the VNX software version - this was not approved to be done by the Fritz agent why?

To the problem here - the check for the version number has some hard coded values to ignore. These are not the right ones at the moment.
Added the right value for the actual CMK version. The other values must be historic as i cannot find somewhere this values.


Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
