### PR TITLE
FreeBSD agent: initialize spooldir (bugfix)

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -92,6 +92,7 @@ set_variable_defaults() {
     : "${MK_CONFDIR:=/etc/check_mk}"
     : "${MK_TMPDIR:=/var/lib/check_mk_agent}"  # TODO: rename to VARDIR
     : "${MK_LOGDIR:=/var/log/check_mk_agent}"
+    : "${SPOOLDIR:=/var/spool/check_mk_agent}"
 
     # some 'booleans'
     [ "${MK_RUN_SYNC_PARTS}" = "false" ] || MK_RUN_SYNC_PARTS=true


### PR DESCRIPTION
BUGFIX:

At least on our systems here `SPOOLDIR` was not set globally by the OS. I found a man page from 1993 SCO Unix indicating that it was also optional and just meant for the SYSV `lp` spooler. Wow, too much history! :-)

In any case:
If it's _not_ set, `check_mk_agent` goes off to do very wild things when the `run_spooler` function is met.
It'll kinda process its workdir as a plugin directory... it'll even try to run itself as far as I saw.

My solution is to simply set `SPOOLDIR` in the agent. Once done, things seemed to work OK again. I didn't do anything like creating the directory here.
(One could also check/initialize the variable in other ways, or trap this in set -u. Maybe it needs addn'l safeguards)

It seems you're now running the agent through shellcheck, I have no input why the tests didn't catch it.

p.s.: the agent being more structured like it is now is a thing of beauty.
p.p.s.: this was the weirdest bug I had to debug in the last few years ;-)
