### PR TITLE
Update check_mk_agent.linux

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1290,7 +1290,7 @@ section_ntp() {
     # First we try to identify if we're beholden to systemd
     if inpath systemctl; then
         # shellcheck disable=SC2016
-        if [ "$(systemctl | awk '/ntp.service|ntpd.service/{print $3; exit}')" = "active" ]; then
+        if [ "$(systemctl | awk '/ntp.service|ntpd.service|ntpsec.service/{print $3; exit}')" = "active" ]; then
             # remove heading, make first column space separated
             get_ntpq
             return


### PR DESCRIPTION
ntpsec is a fork of ntpd which is found in the standard package repositories of a number of distros, including debian and ubuntu.  It behaves in a similar fashion to the ntpd package, replacing timesyncd, and shipping with a ntpq which gives output in the same format.

See https://ntpsec.org/ for more information.

I've been using ntpsec with check_mk_agent under 1.6 with no problems and have used this change to make it work with 2.0 again.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
