### PR TITLE
Fix Bug when ora_pmon Process of Oracle DB is not running

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -2324,7 +2324,7 @@ print_dummy_sections () {
 
 
 do_dummy_sections () {
-    if $MK_ORA_SECTIONS; then
+    if [ -n "$MK_ORA_SECTIONS" ]; then
         return
     fi
 


### PR DESCRIPTION
The modification fix the following Bug:
- We have only one Oracle DB on the Host
- The DB is already monitored ($MK_VARDIR/mk_oracle.found and Services discovered in checkmk)
- When the ora_pmon process of the Oracle DB is not running the Plugin script must print all sections so that the check script on the server can handle this. But due to the bug in the If-Statement the condition is evaluated as true in function do_dummy_sections and is not printing the sections. As a result the Oracle Instance service goes Stale and we can't react on this.

The if condition should check if the Variable MK_ORA_SECTIONS is set and not break the function. With this modification the ORA <Instance> service will go to UNKNOWN and we can get a notification.
