### PR TITLE
Prevent duplicate dual-stack PING service (CRE)

### DIFF
--- a/cmk/base/core_nagios.py
+++ b/cmk/base/core_nagios.py
@@ -624,25 +624,27 @@ def _create_nagios_servicedefs(  # pylint: disable=too-many-branches
 
     if host_config.is_ipv4v6_host:
         if host_config.is_ipv6_primary:
-            _add_ping_service(
-                cfg,
-                config_cache,
-                host_config,
-                host_attrs["_ADDRESS_4"],
-                4,
-                "PING IPv4",
-                host_attrs.get("_NODEIPS_4"),
-            )
+            if "PING IPv4" not in used_descriptions:
+                _add_ping_service(
+                    cfg,
+                    config_cache,
+                    host_config,
+                    host_attrs["_ADDRESS_4"],
+                    4,
+                    "PING IPv4",
+                    host_attrs.get("_NODEIPS_4"),
+                )
         else:
-            _add_ping_service(
-                cfg,
-                config_cache,
-                host_config,
-                host_attrs["_ADDRESS_6"],
-                6,
-                "PING IPv6",
-                host_attrs.get("_NODEIPS_6"),
-            )
+            if "PING IPv6" not in used_descriptions:
+                _add_ping_service(
+                    cfg,
+                    config_cache,
+                    host_config,
+                    host_attrs["_ADDRESS_6"],
+                    6,
+                    "PING IPv6",
+                    host_attrs.get("_NODEIPS_6"),
+                )
 
 
 def _add_ping_service(


### PR DESCRIPTION
## General information

Consider having a dual-stacked host with IPv4 preferred. CRE automatically creates an "PING IPv6" service for this host.

## Bug reports

Previously, the "PING IPv6" service was written to the Nagios config unconditionally, even when you already had a service by that name for that host (presumably manually configured).

## Proposed changes

With this patch, the automatic check is only written to the config file if there is no other check with that description already. This also enables the user to tune the parameters of the service (by creating an active PING check of the same name).
