### PR TITLE
Add options to hide object and object_type i.e. show only summary, da…

### DIFF
--- a/cmk/gui/wato/pages/audit_log.py
+++ b/cmk/gui/wato/pages/audit_log.py
@@ -201,7 +201,7 @@ class ModeAuditLog(WatoMode):
                         css_classes=["toggle"],
                     ),
                     PageMenuEntry(
-                        title=_("Show object type"), 
+                        title=_("Show object type"),
                         icon_name="checked_checkbox" if self._show_object_type else "checkbox",
                         item=make_simple_link(
                             makeactionuri(
@@ -321,13 +321,16 @@ class ModeAuditLog(WatoMode):
                 table.cell(_("User"), user_txt, css=["nobreak narrow"])
 
                 if self._show_object_type:
-                   table.cell(_("Object type"),
-                      entry.object_ref.object_type.name if entry.object_ref else "",
-                      css=["narrow"])
+                    table.cell(
+                        _("Object type"),
+                        entry.object_ref.object_type.name if entry.object_ref else "",
+                        css=["narrow"],
+                    )
 
                 if self._show_object:
-                    table.cell(_("Object"), render_object_ref(entry.object_ref) or "", css=["narrow"])
-
+                    table.cell(
+                        _("Object"), render_object_ref(entry.object_ref) or "", css=["narrow"]
+                    )
 
                 text = HTML(escaping.escape_text(entry.text).replace("\n", "<br>\n"))
                 table.cell(_("Summary"), text)

--- a/cmk/gui/wato/pages/audit_log.py
+++ b/cmk/gui/wato/pages/audit_log.py
@@ -66,6 +66,8 @@ class ModeAuditLog(WatoMode):
         super().__init__()
         self._store = AuditLogStore(AuditLogStore.make_path())
         self._show_details = request.get_integer_input_mandatory("show_details", 1) == 1
+        self._show_object_type = request.get_integer_input_mandatory("show_object_type", 1) == 1
+        self._show_object = request.get_integer_input_mandatory("show_object", 1) == 1
 
     def title(self) -> str:
         return _("Audit log")
@@ -288,12 +290,14 @@ class ModeAuditLog(WatoMode):
                 user_txt = ("<i>%s</i>" % _("internal")) if entry.user_id == "-" else entry.user_id
                 table.cell(_("User"), user_txt, css=["nobreak narrow"])
 
-                table.cell(
-                    _("Object type"),
-                    entry.object_ref.object_type.name if entry.object_ref else "",
-                    css=["narrow"],
-                )
-                table.cell(_("Object"), render_object_ref(entry.object_ref) or "", css=["narrow"])
+                if self._show_object_type:
+                   table.cell(_("Object type"),
+                      entry.object_ref.object_type.name if entry.object_ref else "",
+                      css=["narrow"])
+
+                if self._show_object:
+                    table.cell(_("Object"), render_object_ref(entry.object_ref) or "", css=["narrow"])
+
 
                 text = HTML(escaping.escape_text(entry.text).replace("\n", "<br>\n"))
                 table.cell(_("Summary"), text)

--- a/cmk/gui/wato/pages/audit_log.py
+++ b/cmk/gui/wato/pages/audit_log.py
@@ -199,7 +199,37 @@ class ModeAuditLog(WatoMode):
                         ),
                         name="show_details",
                         css_classes=["toggle"],
-                    )
+                    ),
+                    PageMenuEntry(
+                        title=_("Show object type"), 
+                        icon_name="checked_checkbox" if self._show_object_type else "checkbox",
+                        item=make_simple_link(
+                            makeactionuri(
+                                request,
+                                transactions,
+                                [
+                                    ("show_object_type", "0" if self._show_object_type else "1"),
+                                ],
+                            )
+                        ),
+                        name="show_object_type",
+                        css_classes=["toggle"],
+                    ),
+                    PageMenuEntry(
+                        title=_("Show object"),
+                        icon_name="checked_checkbox" if self._show_object else "checkbox",
+                        item=make_simple_link(
+                            makeactionuri(
+                                request,
+                                transactions,
+                                [
+                                    ("show_object", "0" if self._show_object else "1"),
+                                ],
+                            )
+                        ),
+                        name="show_object",
+                        css_classes=["toggle"],
+                    ),
                 ],
             ),
         )


### PR DESCRIPTION
## General information

Possibly debatable wether this is a bug but it's definitely an inconvenience. One that's easy to fix :).

## Bug reports

Pre-2.0 the audit log was fairly concise, so that some users/customers included the audit log in a dashboard dashlet.
The 2.0 audit log has become more detailed (maybe 2.1 even more, not sure right now), which makes it too wide for some use cases with all the object, object_type, summary etc, columns.
In some cases, only the date, user and summary are required.

## Proposed changes

Analog to the show_details option, add two options for show_object and show_object_type to remove those columns when displaying the audit log to reduce it to only the necessary columns and sort of get the behavior/functionality that was possible in 1.6 back.
