### PR TITLE
mk_oracle: don't remove output of another instance

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -3047,7 +3047,7 @@ main_queries() {
     wait
 
     cat "$ORA_TASKS_TMPDIR/${_QUERY_PREFIX}"*
-    rm -f "$ORA_TASKS_TMPDIR"/*
+    rm -f "$ORA_TASKS_TMPDIR/${_QUERY_PREFIX}"*
 
     #   ---remote---------------------------------------------------------------
 


### PR DESCRIPTION
if running multiple instances of the check (e.g. from two check_mk servers) at the same time, it leads to the problem that the output will be removed from the instance that comes last. This leads to the problem that the oracle instance check will fail.

Fix is to remove only the files that were created by the process itself.
