### PR TITLE
Bug: syslog pid string is not every time numeric

### DIFF
--- a/cmk/ec/event.py
+++ b/cmk/ec/event.py
@@ -285,7 +285,7 @@ def parse_syslog_info(content: str) -> Event:
         application, pid_str = parts[0].split("[", 1)
         pid_str = pid_str.rstrip("]")
         if pid_str.isnumeric():
-            pid = int(pid_str.rstrip("]"))
+            pid = int(pid_str)
         else:
             pid = 0
         text = parts[1].strip()

--- a/cmk/ec/event.py
+++ b/cmk/ec/event.py
@@ -283,7 +283,11 @@ def parse_syslog_info(content: str) -> Event:
         text = content.strip()
     elif "[" in parts[0]:  # TAG followed by pid
         application, pid_str = parts[0].split("[", 1)
-        pid = int(pid_str.rstrip("]"))
+        pid_str = pid_str.rstrip("]")
+        if pid_str.isnumeric():
+            pid = int(pid_str.rstrip("]"))
+        else:
+            pid = 0
         text = parts[1].strip()
     else:  # TAG not followed by pid
         application = parts[0]


### PR DESCRIPTION
The syslog pid part can also be a dash or something else.
This happens often if syslog messages are forwarded or processed from some other instances.

--------------------------------------------

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/tribe29/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
