### PR TITLE
Fix process name of httpd-worker

### DIFF
--- a/agents/plugins/apache_status.py
+++ b/agents/plugins/apache_status.py
@@ -118,6 +118,7 @@ def try_detect_servers(ssl_ports):
         "httpd-prefork",
         "httpd2-prefork",
         "httpd2-worker",
+        "httpd-worker",
         "httpd.worker",
         "httpd-event",
         "fcgi-pm",


### PR DESCRIPTION
## General information

We are currently exploring the check_mk 2.1 agent on SLES12 and SLES15 running Apache httpd with the worker mpm. The process is named httpd-worker and apache_status.py plugin does not autodetect it.

## Proposed changes

The apache_status.py plugin has a list of process names it is checking for auto detection. All variations use a "-". Except "httpd.worker" which looks like a typo to me. That's why I changed it to "httpd-worker" to make autodetection work again. If this was on purpose we should extend the list.
