### PR TITLE
Improve the mk_mysql agent plugin script - allow alias per line

### DIFF
--- a/agents/cfg_examples/mysql.cfg
+++ b/agents/cfg_examples/mysql.cfg
@@ -9,13 +9,17 @@
 [client]
 user=monitoring
 password="password"
-socket=/var/run/mysqld/mysqld.sock
-socket=/var/run/mysqld/mysqld2.sock
+# socket=/var/run/mysqld/mysqld.sock
+# socket=/var/run/mysqld/mysqld2.sock
 
 host=127.0.0.1
 !include /etc/check_mk/mysql.local.cfg
 [check_mk]
 aliases=Alias1,Alias2
+alias=Alias1
+socket=/var/run/mysqld/mysqld.sock
+alias=Alias2
+socket=/var/run/mysqld/mysqld2.sock
 
 # There is always one alias per socket which can also be empty
 # Example with three sockets, the second one has an empty alias:

--- a/agents/plugins/mk_mysql
+++ b/agents/plugins/mk_mysql
@@ -48,21 +48,25 @@ EOF
 fi
 
 if type mysqladmin >/dev/null; then
-    mysql_socket_string=$(grep -F -h socket "$MK_CONFDIR"/mysql{.local,}.cfg | sed -ne 's/.*socket=\([^ ]*\).*/\1/p')
-    alias_string=$(grep -F -h alias "$MK_CONFDIR"/mysql{.local,}.cfg | sed -ne 's/.*aliases=\([^ ]*\).*/\1/p')
+    mysql_sockets=( 
+        $( 2>/dev/null grep -Pho 'socket=\K.+(?=$)' "$MK_CONFDIR"/mysql{.local,}.cfg \
+        || for mysqld_pid in $(pidof mysqld); do
+            xargs -0 printf '%s\n' <"/proc/${mysqld_pid}/cmdline"
+        done | grep -Po -- '--socket=\K.+' )
+    )
 
-    if [ -z "$mysql_socket_string" ]; then
-        mysql_socket_string=$(ps -fww -C mysqld | grep "socket" | sed -ne 's/.*socket=\([^ ]*\).*/\1/p')
-    fi
-    if [ -z "$mysql_socket_string" ]; then
+    if [ ${#mysql_sockets[@]} -eq 0  ]; then
         do_query "" ""
     else
-        IFS=" " mapfile -t mysql_sockets <<<"$mysql_socket_string"
-        IFS="," read -r -a aliases <<<"$alias_string"
-
+        mysql_aliases=(
+            $( 2>/dev/null grep -Pho 'alias=\K.+(?=$)' "$MK_CONFDIR"/mysql{.local,}.cfg )
+        )
+        if [ ${#mysql_aliases[@]} -eq 0  ]; then
+            IFS="," read -r -a mysql_aliases <<<"$( 2>/dev/null grep -Pho 'aliases=\K.+(?=$)' "$MK_CONFDIR"/mysql{.local,}.cfg )"
+        fi
         for i in "${!mysql_sockets[@]}"; do
             socket="${mysql_sockets[i]}"
-            alias="${aliases[i]}"
+            alias="${mysql_aliases[i]}"
             if [ -z "$alias" ]; then
                 do_query "$socket" "$socket"
             else

--- a/agents/plugins/mk_mysql
+++ b/agents/plugins/mk_mysql
@@ -49,7 +49,7 @@ fi
 
 if type mysqladmin >/dev/null; then
     mysql_sockets=( 
-        $( 2>/dev/null grep -Pho 'socket=\K.+(?=$)' "$MK_CONFDIR"/mysql{.local,}.cfg \
+        $( 2>/dev/null grep -Pho 'socket\s*=\s*"?\K[^#"]+(?="?)' "$MK_CONFDIR"/mysql{.local,}.cfg \
         || for mysqld_pid in $(pidof mysqld); do
             xargs -0 printf '%s\n' <"/proc/${mysqld_pid}/cmdline"
         done | grep -Po -- '--socket=\K.+' )
@@ -59,10 +59,10 @@ if type mysqladmin >/dev/null; then
         do_query "" ""
     else
         mysql_aliases=(
-            $( 2>/dev/null grep -Pho 'alias=\K.+(?=$)' "$MK_CONFDIR"/mysql{.local,}.cfg )
+            $( 2>/dev/null grep -Pho 'alias\s*=\s*"?\K[^#"]+(?="?)' "$MK_CONFDIR"/mysql{.local,}.cfg )
         )
         if [ ${#mysql_aliases[@]} -eq 0  ]; then
-            IFS="," read -r -a mysql_aliases <<<"$( 2>/dev/null grep -Pho 'aliases=\K.+(?=$)' "$MK_CONFDIR"/mysql{.local,}.cfg )"
+            IFS="," read -r -a mysql_aliases <<<"$( 2>/dev/null grep -Pho 'aliases\s*=\s*"?\K[^#"]+(?="?)' "$MK_CONFDIR"/mysql{.local,}.cfg )"
         fi
         for i in "${!mysql_sockets[@]}"; do
             socket="${mysql_sockets[i]}"


### PR DESCRIPTION
example cfg section for check_mk with alias= entries. aliases should work too when alias= is not present socket= is only moved to its corresponding alias=

improved the mk_mysql logic
should allow what was previously configured too

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/tribe29/checkmk#want-to-contribute) regarding process details.

## General information

Update agent plugin `mk_mysql` to allow `alias=` per line instead of one `aliases=` with each alias as an item of a comma seperated list.
This makes it easier to provision `"$MK_CONFDIR"/mysql{.local,}.cfg` with ansible module block in file.

## Bug reports
no bug report.
the previous solution was not useful for a lot of galera cluster instances.

## Proposed changes

The new code should work with old config.
But now also allows to write a check_mk cfg file in the following stile.

```txt
[check_mk]
...
# BEGIN ANSIBLE MANAGED BLOCK Alias1
alias=Alias1
socket=/path/to/my-alias1.sock
# END ANSIBLE MANAGED BLOCK Alias1
# BEGIN ANSIBLE MANAGED BLOCK Alias1
alias=Alias2
socket=/path/to/my-alias2.sock
# END ANSIBLE MANAGED BLOCK Alias1
```

> While it may work for you, it is our job to ensure that it works for everybody.
I hope the provided solution should work for everybody using the mk_mysql agent plugin.

+ If it's not obvious from the above: In what way does your patch change the current behavior?
If there is no `alias=` entry but if there is the `aliases=Alias1,Alias2` the code should still work.

+ Consider writing a unit test that would have failed without your fix.
There is no fix. The previous behaviour should work too.

+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
It allows/provides a cleaner structure for cfg files with a lot of mysql instances.
Actually it fixes even some issues with parsing sockets from running mysqld processes where the `--socket=path/to/sock` is not at the end.

