### PR TITLE
Fix for ZFS Pools that use a "Special" device

### DIFF
--- a/cmk/base/plugins/agent_based/zpool_status.py
+++ b/cmk/base/plugins/agent_based/zpool_status.py
@@ -86,7 +86,9 @@ def parse_zpool_status(  # pylint: disable=too-many-branches
             continue
 
         elif start_pool is True:
-            if line[1] != "ONLINE":
+            if len(line) == 1:
+                continue
+            elif line[1] != "ONLINE":
                 error_pools[line[0]] = tuple(line[1:])
             elif saveint(line[4]) != 0:
                 warning_pools[line[0]] = tuple(line[1:])


### PR DESCRIPTION
One of our servers ran into issues with this check due to the addition of a "Special" device, which can be added to a zfs pool for metadata storage.
    The output generated results in a out of index error.
    Here the agent output that resulted in the checks crash:

<<<zpool_status>>>
  pool: backup
 state: DEGRADED
status: One or more devices are faulted in response to persistent errors.
        Sufficient replicas exist for the pool to continue functioning in a
        degraded state.
action: Replace the faulted device, or use 'zpool clear' to mark the device
        repaired.
  scan: scrub repaired <removed date/time>
config:

        NAME          STATE     READ WRITE CKSUM
        backup  DEGRADED     0     0     0
          raidz2-0    DEGRADED     0     0     0
            sdc       FAULTED      3     0     0  too many errors
            sdd       ONLINE       0     0     0
            sde       ONLINE       0     0     0
            sdf       ONLINE       0     0     0
            sdg       ONLINE       0     0     0
            sdh       ONLINE       0     0     0
            sdi       ONLINE       0     0     0
            sdj       ONLINE       0     0     0
            sdk       ONLINE       0     0     0
            sdl       ONLINE       0     0     0
        special
          mirror-1    ONLINE       0     0     0
            nvme0n1   ONLINE       0     0     0
            nvme1n1   ONLINE       0     0     0

errors: No known data errors

The special device is part of the pool and doesn't seem to have its own status displayed, which causes the check to fail, as it expects the line to consist of 5 words.