### PR TITLE
Extended scan function of ibm_tape_library.py to be able to discover …

### DIFF
--- a/cmk/base/check_legacy_includes/ibm_tape_library.py
+++ b/cmk/base/check_legacy_includes/ibm_tape_library.py
@@ -8,7 +8,11 @@
 
 
 def scan_ibm_tape_library(oid):
-    return oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.32925.1")
+        return (
+        oid(".1.3.6.1.4.1.14851.3.1.3.5.0").startswith("IBM TS4300 Tape Library")
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.32925.1")
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.14851")
+    )
 
 
 def ibm_tape_library_parse_device_name(name):


### PR DESCRIPTION
This patch is only against the 2.1.0 branch, because in the master branch, the scan function is not in ~/lib/python3/cmk/base/check_legacy_includes/ibm_tape_library.py anymore

…IBM TS4300 Tape Library

Extended scan function of ibm_tape_library.py to be able to discover IBM TS4300 Tape Library

References

- https://forum.checkmk.com/t/ibm-ts-4300-got-empty-snmp-response/31004
- SUP-12553
- SUP-14102