### PR TITLE
tsm_scratch: Correctly handle 0 scratch tapes

### DIFF
--- a/agents/windows/plugins/tsm_checks.bat
+++ b/agents/windows/plugins/tsm_checks.bat
@@ -13,7 +13,7 @@ echo ^<^<^<tsm_sessions^>^>^>
 %COMMAND% "select session_id, client_name, state, wait_seconds from sessions"
 
 echo ^<^<^<tsm_scratch^>^>^>
-%COMMAND% "select 'default', count(library_name), library_name from libvolumes where status='Scratch' group by library_name"
+%COMMAND% "select 'default', count(libvolumes.status), libraries.library_name from libraries left outer join libvolumes on libraries.library_name = libvolumes.library_name and status='Scratch' group by libraries.library_name"
 
 echo ^<^<^<tsm_storagepools^>^>^>
 %COMMAND% "select 'default', type, stgpool_name, sum(logical_mb) from occupancy group by type, stgpool_name"


### PR DESCRIPTION
Previously, the query would return nothing when no scratch tapes are found, causing the service to become unknown:
```
<<<tsm_scratch>>>
ANR2034E SELECT: No match found using this criteria.
```

Now, it outputs the correct amount:
```
<<<tsm_scratch>>>
default                   0     IBM3592                         
```