### PR TITLE
Avoid agent hanging in case of issues with /proc/PID/cmdline

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -96,7 +96,7 @@ set_up_get_epoch() {
 set_up_current_shell() {
     # Note the current shell may not be the same as what is specified in the
     # shebang, e.g. when reconfigured in the xinetd/systemd/whateverd config file
-    CURRENT_SHELL="$(ps -o args= -p $$ | cut -d' ' -f1)"
+    CURRENT_SHELL="$(waitmax -s 9 2 ps -o args= -p $$ | cut -d' ' -f1)"
 }
 
 #
@@ -583,7 +583,7 @@ section_systemd() {
         echo "[list-unit-files]"
         systemctl list-unit-files --full --no-legend --no-pager --plain --type service --type socket | tr -s ' '
         echo "[status]"
-        systemctl status --all --type service --type socket --no-pager --lines 0 | tr -s ' '
+        waitmax -s 9 5 systemctl status --all --type service --type socket --no-pager --lines 0 | tr -s ' ' || echo
         echo "[all]"
         systemctl --all --type service --type socket --full --no-legend --no-pager --plain | sed '/^$/q' | tr -s ' '
     fi
@@ -658,7 +658,7 @@ section_ps() {
         if [ -e /sys/fs/cgroup ]; then
             CGROUP="cgroup:512,"
         fi
-        echo "[header] $(ps ax -ww -o "${CGROUP}"user:32,vsz,rss,cputime,etime,pid,command | tr -s ' ')"
+        echo "[header] $(waitmax -s 9 5 ps ax -ww -o "${CGROUP}"user:32,vsz,rss,cputime,etime,pid,command | tr -s ' ' || echo)"
     fi
 }
 
@@ -944,7 +944,7 @@ section_drbd() {
 }
 
 section_heartbeat() {
-    if [ -S /var/run/heartbeat/crm/cib_ro ] || [ -S /var/run/crm/cib_ro ] || pgrep "^(crmd|pacemaker-contr)$" >/dev/null 2>&1; then
+    if [ -S /var/run/heartbeat/crm/cib_ro ] || [ -S /var/run/crm/cib_ro ] || waitmax -s 9 5 pgrep "^(crmd|pacemaker-contr)$" >/dev/null 2>&1; then
         echo '<<<heartbeat_crm>>>'
         TZ=UTC crm_mon -1 -r | grep -v ^$ | sed 's/^ //; /^\sResource Group:/,$ s/^\s//; s/^\s/_/g'
     fi


### PR DESCRIPTION
We have witnessed an issue where a container in a Kubernetes environment would not be cleaned up properly after having CrashLoopBackOff state. In this case, when trying to access /proc/PID/cmdline, ps will simply hang forever.

Because ps-related commands are run as-is by the Checkmk agent the check_mk_agent process itself will hang as well. This then leads to:
- a timeout on the Checkmk server
- one check_mk_agent process (and consequently, one ps process) being spawned every check interval
- finally, very high CPU load on the system caused by IO wait of the hundreds of hanging processes, rendering the system unusable for production workload.

All the affected systems are running Red Hat Enterprise Linux 8.8.
Checkmk version is 2.1.0p16. Since this really is a misbehaviour of the underlying OS, other versions will be affected as well.

External resource describing this issue (and possible reasons): https://rachelbythebay.com/w/2014/10/27/ps/

## Proposed changes

The proposed fix simply adds a `waitmax -s 9 5` (and an extra `echo` for section_ps) to the two commands in the agent that rely on the command output of processes. This command is already present for other sections like nfs mounts, tcp information, and such. Affected are:
- the ps command used in section_ps
- the pgrep command used in section_heartbeat (required because pgrep relies on the process' cmdline by design)
- the scond systemctl command in section_systemd used for `[status]`
- the ps command used to determine `CURRENT_SHELL`

_**Note**: The 5 seconds grace period are an arbitrary value that seemed reasonable to us and was not deduced from detailed analysis or similar._

### Result

If a host is facing this issue with being unable to access the cmdline of a process, waitmax will kill the ps or pgrep process after 5 seconds. The agent output will thus be delayed a little, yet will continue with other sections.

As a (potentially hidden) side-effect the monitoring of processes will break, if a monitored process would be listed after the one having issues with its cmdline.

### Reasoning

Even though this issue can be considered a bug-like behaviour of the OS itself, we still think this fix should be implemented into the agent. This ensures the host is still being monitored although there might be issues with the processes. As of now, the Checkmk agent will simply run into timeouts as soon as ps starts hanging, rendering the monitoring of this host unusable.