### PR TITLE
FIXES: "Cannot render negative timespan"

### DIFF
--- a/cmk/base/api/agent_based/render.py
+++ b/cmk/base/api/agent_based/render.py
@@ -104,7 +104,12 @@ def timespan(seconds: float) -> str:
         '100 years 0 days'
 
     """
-    ts = " ".join(_gen_timespan_chunks(float(seconds), nchunks=2))
+    if seconds >= 0:
+        ts = " ".join(_gen_timespan_chunks(float(seconds), nchunks=2))
+    else:
+        seconds = -1 * seconds
+        ts = " ".join(_gen_timespan_chunks(float(seconds), nchunks=2))
+        ts = "-%s" % ts
     if ts == "0 %s" % _TIME_UNITS[-1][0]:
         ts = "0 seconds"
     return ts


### PR DESCRIPTION
`_gen_timespan_chunks` raises the exception "Cannot render negative timespan" 

This PR adds the ability to render a negative timespan. One should expect to be able to also render a negative timespan.