### PR TITLE
FIXES: "Cannot render negative timespan"

### DIFF
--- a/cmk/base/api/agent_based/render.py
+++ b/cmk/base/api/agent_based/render.py
@@ -104,7 +104,12 @@ def timespan(seconds: float) -> str:
         '100 years 0 days'
 
     """
-    ts = " ".join(_gen_timespan_chunks(float(seconds), nchunks=2))
+    if seconds >= 0:
+        ts = " ".join(_gen_timespan_chunks(float(seconds), nchunks=2))
+    else:
+        seconds = -1 * seconds
+        ts = " ".join(_gen_timespan_chunks(float(seconds), nchunks=2))
+        ts = "-%s" % ts
     if ts == "0 %s" % _TIME_UNITS[-1][0]:
         ts = "0 seconds"
     return ts

--- a/tests/unit/cmk/base/api/agent_based/test_render_api.py
+++ b/tests/unit/cmk/base/api/agent_based/test_render_api.py
@@ -55,9 +55,22 @@ def test_timespan(seconds: float, output: str) -> None:
     assert output == render.timespan(seconds=seconds)
 
 
-def test_timespan_negative() -> None:
-    with pytest.raises(ValueError):
-        _ = render.timespan(seconds=-1.0)
+@pytest.mark.parametrize(
+    "seconds, output",
+    [
+        (-0, "0 seconds"),
+        (-0.00000001, "-10 nanoseconds"),
+        (-5.3991e-05, "-54 microseconds"),
+        (-0.1, "-100 milliseconds"),
+        (-22, "-22 seconds"),
+        (-158, "-2 minutes 38 seconds"),
+        (-98, "-1 minute 38 seconds"),
+        (-1234567, "-14 days 6 hours"),
+        (-31536001, "-1 year 0 days"),
+    ],
+)
+def test_timespan_negative(seconds: float, output: str) -> None:
+    assert output == render.timespan(seconds=seconds)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`_gen_timespan_chunks` raises the exception `"Cannot render negative timespan"`

This PR adds the ability to render a negative timespan. One should expect to be able to also render a negative timespan.