### PR TITLE
FIXES: wrong order of metrics in bandwith graph

### DIFF
--- a/cmk/gui/plugins/metrics/network.py
+++ b/cmk/gui/plugins/metrics/network.py
@@ -1688,8 +1688,8 @@ metric_info["used_snat_ports"] = {
 graph_info["bandwidth_translated"] = {
     "title": _("Bandwidth"),
     "metrics": [
-        ("if_out_octets,8,*@bits/s", "area", _("Input bandwidth")),
-        ("if_in_octets,8,*@bits/s", "-area", _("Output bandwidth")),
+        ("if_out_octets,8,*@bits/s", "area", _("Output bandwidth")),
+        ("if_in_octets,8,*@bits/s", "-area", _("Input bandwidth")),
     ],
     "scalars": [
         ("if_in_octets:warn", _("Warning (In)")),

--- a/cmk/gui/plugins/metrics/network.py
+++ b/cmk/gui/plugins/metrics/network.py
@@ -1688,8 +1688,8 @@ metric_info["used_snat_ports"] = {
 graph_info["bandwidth_translated"] = {
     "title": _("Bandwidth"),
     "metrics": [
-        ("if_in_octets,8,*@bits/s", "area", _("Input bandwidth")),
-        ("if_out_octets,8,*@bits/s", "-area", _("Output bandwidth")),
+        ("if_out_octets,8,*@bits/s", "area", _("Input bandwidth")),
+        ("if_in_octets,8,*@bits/s", "-area", _("Output bandwidth")),
     ],
     "scalars": [
         ("if_in_octets:warn", _("Warning (In)")),
@@ -1704,11 +1704,11 @@ graph_info["bandwidth"] = {
     "title": _("Bandwidth"),
     "metrics": [
         (
-            "if_in_bps",
+            "if_out_bps",
             "area",
         ),
         (
-            "if_out_bps",
+            "if_in_bps",
             "-area",
         ),
     ],


### PR DESCRIPTION
The interface bandwidth graph displays the input/output bandwidth metrics in a non-uniform order. In the diagram, the input bandwidth is in the upper half and the output bandwidth is in the lower half of the diagram. In the legend and tooltip, it is the other way around.

This PW will change the order of the Input/Output bandwith in the legend and the tool tip.

For more (graphical) detail have a look at 

https://forum.checkmk.com/t/servicegraphen-kosmetische-anfrage/29906/8