### PR TITLE
monitor nginx_status endpoint even if has invalid ssl

### DIFF
--- a/agents/plugins/nginx_status.py
+++ b/agents/plugins/nginx_status.py
@@ -25,6 +25,11 @@ import re
 import sys
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+import ssl
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
 
 if sys.version_info < (2, 6):
     sys.stderr.write("ERROR: Python 2.5 is not supported. Please use Python 2.6 or newer.\n")
@@ -158,7 +163,7 @@ def main():  # pylint: disable=too-many-branches
             # Try to fetch the status page for each server
             try:
                 request = Request(url, headers={"Accept": "text/plain", "User-Agent": USER_AGENT})
-                fd = urlopen(request)  # nosec B310 # BNS:6b61d9
+                fd = urlopen(request, context=ctx)  # nosec B310 # BNS:6b61d9
             except URLError as e:
                 if "SSL23_GET_SERVER_HELLO:unknown protocol" in str(e):
                     # HACK: workaround misconfigurations where port 443 is used for


### PR DESCRIPTION
## General information

the existing code would fail if it attempted to monitor a site with an invalid SSL cert (eg https://localhost)
a cert expiry would also stop monitoring

## Bug reports

output before code change
```
./nginx_status.py
<<<nginx_status>>>
Exception (127.0.0.1:443): <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:1129)>
```

## Proposed changes

code changes skips cert validation
result:
```
./nginx_status.py
<<<nginx_status>>>
127.0.0.1 443 Active connections: 5
127.0.0.1 443 server accepts handled requests
127.0.0.1 443  718 718 3030
127.0.0.1 443 Reading: 0 Writing: 1 Waiting: 4
```