### PR TITLE
netapp_api_luns: Added missing Lun Informations

### DIFF
--- a/cmk/base/plugins/agent_based/netapp_api_luns.py
+++ b/cmk/base/plugins/agent_based/netapp_api_luns.py
@@ -67,7 +67,6 @@ def _check_netapp_api_luns(
     if lun.get("online") != "true":
         yield Result(state=State.CRIT, summary="LUN is offline")
 
-
     read_only = lun.get("read-only") == "true"
     if read_only != params.get("read_only"):
         expected = str(params.get("read_only")).lower()

--- a/cmk/base/plugins/agent_based/netapp_api_luns.py
+++ b/cmk/base/plugins/agent_based/netapp_api_luns.py
@@ -61,8 +61,12 @@ def _check_netapp_api_luns(
     if (lun := section.get(item)) is None:
         return
 
+    yield Result(state=State.OK, summary=f"Volume: {lun['volume']}")
+    yield Result(state=State.OK, summary=f"Vserver: {lun['vserver']}")
+
     if lun.get("online") != "true":
         yield Result(state=State.CRIT, summary="LUN is offline")
+
 
     read_only = lun.get("read-only") == "true"
     if read_only != params.get("read_only"):


### PR DESCRIPTION
If you have a Setup with Multiple Netapps and Thousands of Luns, it's currently not possible to figure out to where a Lun belongs.

With this small Change, this information is now part of the Check Output. 


I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.