### PR TITLE
Fixes: is not a valid PhysicalClasses

### DIFF
--- a/cmk/base/plugins/agent_based/utils/entity_mib.py
+++ b/cmk/base/plugins/agent_based/utils/entity_mib.py
@@ -24,8 +24,7 @@ class PhysicalClasses(Enum):
     # SUP-10602: Cisco decided to not stick to the official MiB ...
     @classmethod
     def parse_cisco(cls, raw_phys_class: str) -> "PhysicalClasses":
-        match raw_phys_class:
-            case "0" | "" | "14":
-                return cls.unknown
-            case _:
-                return cls(raw_phys_class)
+        try:
+            return cls(raw_phys_class)
+        except ValueError:
+            return cls.unknown


### PR DESCRIPTION
In PhysicalClasses are only the values from 1 to 12 defined (this is acording to the MIB description).  For all other values is an explicit errorhandling implemented (currently only for "0","" and "14"). This fix will change this, so that for every value other than 1-12 the physical classe "unknown" is returned.

Werk 15633 was only fixing this error for the value 14.

One Example from a Cisco Stack:

        ['1001', '13', 'StackPort1'],
        ['1002', '14', 'StackAdapter1'],
        
Here the value 13 results in a crash of the inventory plugins.

