### PR TITLE
Fixes: hr_fs': 'item' must be a non empty string

### DIFF
--- a/cmk/base/plugins/agent_based/hr_fs.py
+++ b/cmk/base/plugins/agent_based/hr_fs.py
@@ -58,7 +58,8 @@ def parse_hr_fs(string_table: StringTable) -> Section:
         except ValueError:
             continue
 
-        section.append((fix_hr_fs_mountpoint(hrdescr), size_mb, size_mb - used_mb, 0))
+        if hrdescr:
+            section.append((fix_hr_fs_mountpoint(hrdescr), size_mb, size_mb - used_mb, 0))
 
     return section
 


### PR DESCRIPTION
The hr_fs check plugin crashes if the  the mount point description is empty. 
This fix will drop such mount points in the parse function.

One example for such a system are Cisco AsyncOS appliances (E-Mail/Web Security)

Here a string table from such a device:
```
string_table = [
    ['.1.3.6.1.2.1.25.2.1.2', '', '4096', '8375974', '1539607'],
    ['.1.3.6.1.2.1.25.2.1.2', '', '4096', '734050', '1197'],
    ['.1.3.6.1.2.1.25.2.1.3', '', '4096', '3262172', '34624'],
    ['.1.3.6.1.2.1.25.2.1.1', '', '1024', '1697280', '1695504'],
    ['.1.3.6.1.2.1.25.2.1.1', '', '4096', '319187', '-352236'],
    ['.1.3.6.1.2.1.25.2.1.1', '', '4096', '44784', '16302'],
    ['.1.3.6.1.2.1.25.2.1.1', '', '4096', '17735', '1096'],
    ['.1.3.6.1.2.1.25.2.1.3', '', '4096', '2097136', '0'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '8192', '50287', '24792'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '512', '2', '2'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '8192', '50287', '43739'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '2048', '198263', '3940'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '8192', '138632473', '21516404'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '2048', '6093095', '34'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '4096', '1', '1'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '4096', '1', '1'],
    ['.1.3.6.1.2.1.25.2.1.4', '', '4096', '1', '1']
]
```
