### PR TITLE
Fixes: cisco_asa_conn crashes on empty interface status

### DIFF
--- a/cmk/base/legacy_checks/cisco_asa_conn.py
+++ b/cmk/base/legacy_checks/cisco_asa_conn.py
@@ -61,7 +61,7 @@ def check_cisco_asa_conn(item, _no_params, parsed):
             else:  # CRIT if no IP is assigned
                 yield 2, "IP: Not found!"
 
-            state, state_readable = translate_status[values[2], (3, "N/A")]
+            state, state_readable = translate_status.get(values[2], (3, "N/A"))
             yield state, "Status: %s" % state_readable
 
 

--- a/cmk/base/legacy_checks/cisco_asa_conn.py
+++ b/cmk/base/legacy_checks/cisco_asa_conn.py
@@ -61,7 +61,7 @@ def check_cisco_asa_conn(item, _no_params, parsed):
             else:  # CRIT if no IP is assigned
                 yield 2, "IP: Not found!"
 
-            state, state_readable = translate_status[values[2]]
+            state, state_readable = translate_status[values[2], (3, 'N/A')]
             yield state, "Status: %s" % state_readable
 
 

--- a/cmk/base/legacy_checks/cisco_asa_conn.py
+++ b/cmk/base/legacy_checks/cisco_asa_conn.py
@@ -61,7 +61,7 @@ def check_cisco_asa_conn(item, _no_params, parsed):
             else:  # CRIT if no IP is assigned
                 yield 2, "IP: Not found!"
 
-            state, state_readable = translate_status[values[2], (3, 'N/A')]
+            state, state_readable = translate_status[values[2], (3, "N/A")]
             yield state, "Status: %s" % state_readable
 
 


### PR DESCRIPTION
cisco_asa_conn crashes on empty interface status. This fix will return a "N/A"/Unknown state for such interfaces insted of a crash.

This happens on Cisco Firepower Appliances.
