### PR TITLE
Fix failing config migration in caused by viprinet_router checks

### DIFF
--- a/cmk/gui/plugins/wato/check_parameters/viprinet_router.py
+++ b/cmk/gui/plugins/wato/check_parameters/viprinet_router.py
@@ -29,6 +29,7 @@ def _parameter_valuespec_viprinet_router():
                 ),
             ),
         ],
+        ignored_keys=["mode_inv"],
     )
 
 


### PR DESCRIPTION
The WATO rule did not declare the check parameter key "mode_inv" used to remember the state during discovery, causing it to be dropped and thus failing the automatic config migration.

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
