### PR TITLE
Added new val 10 for System

### DIFF
--- a/cmk/base/legacy_checks/emc_datadomain_disks.py
+++ b/cmk/base/legacy_checks/emc_datadomain_disks.py
@@ -26,6 +26,7 @@ def check_emc_datadomain_disks(item, _no_params, info):
         "4": ("Failed", 2),
         "5": ("Spare", 0),
         "6": ("Available", 0),
+        "8": ("System", 0),
     }
     for line in info[0]:
         if item == line[0] + "-" + line[1]:


### PR DESCRIPTION
### Problem

emc_datadomain_disks.py will stumble upon a new status "10" for old .1.3.6.1.4.1.19746.1.6.1.1.1.8 which is according to the web gui "System" and shall be treated as OK and not as UNKN.

