### PR TITLE
replace tab with space characters to correct "-->" indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
         protobuf-files
 
 help:
-	@echo "setup			      --> Prepare system for development and building"
+	@echo "setup                          --> Prepare system for development and building"
 	@echo "make dist                      --> Create source tgz for later building of rpm/deb and livestatus tgz"
 	@echo "make rpm                       --> Create rpm package"
 	@echo "make deb                       --> Create deb package"


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

tab keys messed up the indention of "make help"

## Bug reports

Please include:

+ Your operating system name and version
all OS not just on rocky linux.


+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

replace tab key with correct space characters.

```


+ What is the expected behavior?

[me@rocky9t01 checkmk]$ make
setup                          --> Prepare system for development and building
make dist                      --> Create source tgz for later building of rpm/deb and livestatus tgz
<snipped>
[me@rocky9t01 checkmk]$ 
```
+ What is the observed behavior?
"-->" shifted left one character to break the indentation.
```
[me@rocky9t01 checkmk]$ make help
setup                         --> Prepare system for development and building
make dist                      --> Create source tgz for later building of rpm/deb and livestatus tgz
<snipped>
[me@rocky9t01 checkmk]$
```
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
