### PR TITLE
proxmox_ve: Don't crash on empty log lines

### DIFF
--- a/cmk/special_agents/agent_proxmox_ve.py
+++ b/cmk/special_agents/agent_proxmox_ve.py
@@ -103,7 +103,7 @@ class BackupTask:
         if dump_logs:
             with (LogCacheFilePath / (f"{task['upid']}.log")).open("w") as file:
                 LOGGER.debug("wrote log to: %s", file.name)
-                file.write("\n".join(line["t"] for line in logs))
+                file.write("\n".join(line["t"] for line in logs if "t" in line))
 
         try:
             self.backup_data, errors = self._extract_logs(self._to_lines(logs), strict)
@@ -129,7 +129,7 @@ class BackupTask:
                     task["upid"],
                     file.name,
                 )
-                file.write("\n".join(line["t"] for line in logs))
+                file.write("\n".join(line["t"] for line in logs if "t" in line))
                 for linenr, text in errors:
                     file.write("PARSE-ERROR: %d: %s\n" % (linenr, text))
 
@@ -144,6 +144,7 @@ class BackupTask:
         return (
             line
             for elem in lines_with_numbers
+            if "t" in elem
             for line in (elem["t"],)
             if isinstance(line, str) and line.strip()
         )  #  #  #  #


### PR DESCRIPTION
For one of our hypervisors in one of our clusters, the Proxmox VE special agent suddenly crashed with the error message

```
Caught unhandled KeyError('t') in /omd/sites/plutex/lib/python3/cmk/special_agents/utils/agent_common.py:135
```

Apparently some empty log line in one of the jobs that was causing this crash. No idea why it was there, but the agent shouldn't crash, so we patched it to assume an empty line when there is none in the object.