### PR TITLE
Add starting as an OK state for Veeam Jobs

### DIFF
--- a/cmk/base/legacy_checks/veeam_jobs.py
+++ b/cmk/base/legacy_checks/veeam_jobs.py
@@ -35,7 +35,7 @@ def check_veeam_jobs(item, _no_params, info):
         if job_name != item:
             continue  # Skip not matching lines
 
-        if job_last_state in ["Working", "Postprocessing"]:
+        if job_last_state in ["Starting", "Working", "Postprocessing"]:
             return 0, "Running since {} (current state is: {})".format(
                 job_creation_time,
                 job_last_state,


### PR DESCRIPTION
## General information
Veeam Jobs have a state of `Starting` that causes the service to be in an `UNKNOWN` state.

## Proposed changes
This treats `Starting` the same as `Working` and `Postprocessing`.