### PR TITLE
Update apc_ats_status

### DIFF
--- a/checks/apc_ats_status
+++ b/checks/apc_ats_status
@@ -11,7 +11,7 @@ def inventory_apc_ats_status(info):
 
 
 def check_apc_ats_status(_no_item, source, info):
-    comstatus, selected_source, redundancy, overcurrent, ps5, ps24 = map(saveint, info[0])
+    comstatus, selected_source, redundancy, overcurrent, ps5, ps24, ps3, ps1 = map(saveint, info[0])
     state = 0
     messages = []
 
@@ -52,14 +52,27 @@ def check_apc_ats_status(_no_item, source, info):
         messages.append("exceedet ouput current threshold(!!)")
 
     # 5Volt power supply
-    if ps5 != 2:
-        state = 2
-        messages.append("5V power supply failed(!!)")
+    if ps5:
+        if ps5 != 2:
+            state = 2
+            messages.append("5V power supply failed(!!)")
 
     # 24Volt power supply
     if ps24 != 2:
         state = 2
         messages.append("24V power suppy failed(!!)")
+
+    # 3.3Volt power supply
+    if ps3:
+        if ps3 != 2:
+            state = 2
+            messages.append("3.3V power supply failed(!!)")
+
+    # 1Volt power supply
+    if ps1:
+        if ps1 != 2:
+            state = 2
+            messages.append("1V power supply failed(!!)")
 
     return state, ", ".join(messages)
 
@@ -68,7 +81,11 @@ check_info["apc_ats_status"] = {
     "check_function": check_apc_ats_status,
     "inventory_function": inventory_apc_ats_status,
     "service_description": "ATS Status",
-    "snmp_scan_function": lambda oid: ".1.3.6.1.4.1.318.1.3.11" in oid(".1.3.6.1.2.1.1.2.0"),
+    "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0")
+    in [
+        ".1.3.6.1.4.1.318.1.3.11",
+        ".1.3.6.1.4.1.318.1.3.32",
+    ],
     "snmp_info": (
         ".1.3.6.1.4.1.318.1.1.8.5.1",
         [
@@ -78,6 +95,8 @@ check_info["apc_ats_status"] = {
             "4.0",  # atsStatusOverCurrentState
             "5.0",  # atsStatus5VPowerSupply
             "6.0",  # atsStatus24VPowerSupply
+            "17.0", # atsStatus3dot3VPowerSupply
+            "18.0", # atsStatus1Dot0VPowerSupply
         ],
     ),
 }


### PR DESCRIPTION
Adding support for units such as the APC AP4450 with no 5V PSU but a 3.3V and 1V PSUs instead. See https://forum.checkmk.com/t/issues-with-apc-pdu-transfer-switch-check-mk-apc-ats-output/41110 for more details.