### PR TITLE
Improve apc_ats_output and add support for some units

### DIFF
--- a/checks/apc_ats_output
+++ b/checks/apc_ats_output
@@ -73,8 +73,7 @@ def check_apc_ats_output(item, params, data):
 
 
 factory_settings["apc_ats_output_default_levels"] = {
-    "output_voltage_max": (127, 136),
-    "output_voltage_min": (106, 97),
+    "output_voltage_max": (240, 250),
     "load_perc_max": (85, 95),
 }
 

--- a/checks/apc_ats_output
+++ b/checks/apc_ats_output
@@ -43,12 +43,26 @@ def check_apc_ats_output(item, params, data):
             unit="V",
         )
     if power is not None:
-        yield 0, "Power: %.2f W" % power
+        yield check_levels(
+            power,
+            "watt",
+            params.get("output_power_max", (None, None))
+            + params.get("output_power_min", (None, None)),
+            infoname="Power",
+            unit="W",
+        )
 
     if current is not None:
-        yield 0, "Current: %.2f A" % current
+        yield check_levels(
+            current,
+            "current",
+            params.get("output_current_max", (None, None))
+            + params.get("output_current_min", (None, None)),
+            infoname="Current",
+            unit="A",
+        )
 
-    if perc_load is not None:
+    if perc_load not in (None, -1):
         yield check_levels(
             perc_load,
             "load_perc",
@@ -59,7 +73,8 @@ def check_apc_ats_output(item, params, data):
 
 
 factory_settings["apc_ats_output_default_levels"] = {
-    "output_voltage_max": (240, 250),
+    "output_voltage_max": (127, 136),
+    "output_voltage_min": (106, 97),
     "load_perc_max": (85, 95),
 }
 


### PR DESCRIPTION
Added charts for the current and the power levels. Fixed an issue with some units returning -1 as the load value when not supported. 

More info here: https://forum.checkmk.com/t/issues-with-apc-pdu-transfer-switch-check-mk-apc-ats-output/41110