### PR TITLE
Fix false positives regarding notification errors

### DIFF
--- a/cmk/notification_plugins/pushover.py
+++ b/cmk/notification_plugins/pushover.py
@@ -120,7 +120,7 @@ def send_push_notification(
         sys.stdout.write("POST request to server failed: %s\n" % api_url)
         return 1
 
-    if response.status_code != 200:
+    if response.status_code not in [200, 204]:
         sys.stdout.write(
             "Failed to send notification. Status: %s, Response: %s\n"
             % (response.status_code, response.text)


### PR DESCRIPTION
Summary:
This small change leads to fewer entries about failed notifications.
Although notifications by mail or webex are coming through without any problems, an entry regarding failed notifications sometimes gets generated.

Background/Problem:
After a notification is sent, the api sometimes does not get a 200 status code as a response, but a 204 ("No content") instead.
Currently this gets flagged as an error, because every status except 200 is treated as an unsuccesful notification (line 123 in pushover.py).

Result:
With this small change, a 204 status code does not lead to the error "Failed to send notification" anymore.