### PR TITLE
ups_power: Handle empty power reporting gracefully

### DIFF
--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -18,7 +18,10 @@ def parse_ups_power(
         if not voltage_str or not int(voltage_str):
             continue
 
-        power = int(power_str)
+        try:
+            power = int(power_str)
+        except ValueError:
+            continue
         # Some "RPS SpA" systems are not RFC conform in this value.
         # The values can get negative but should never be.
         if power < 0:


### PR DESCRIPTION
With the upgrade from 2.1 to 2.2, the new ups_power section (see commit 80f80ec5982a447cd604c20fe0766ca7708ac173) fails parsing SNMP responses to UPS-MIB where the power OID (.1.3.6.1.2.1.33.1.4.4.1.4) is empty - which cannot be converted to an int and triggers a ValueError in the section parser.

In our setup, we modified utils/ups.py to include every device that has a UPS-MIB. In particular, this enables us to monitor UPS attached to Mikrotik network devices via their ups package. While this particular scenario might not be possible without modifying utils/ups.py (because Mikrotik devices otherwise aren't polled for UPS-MIB data), other devices might trigger the same problem.

(The old implementation used `saveint()` to convert the OID to an integer, thus simply implying a 0 for an empty reply. The new behavior of this PR improves over that by not discovering a service at all.)