### PR TITLE
Fixes ups_power.py crashes on missing power value

### DIFF
--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -19,6 +19,10 @@ def parse_ups_power(
             power = int(power_str)
         except ValueError:
             continue
+        # just to keep pylint happy, Unused variable 'voltage_str' (unused-variable) 
+        # voltage_str could be completely removed
+        voltage_str = voltage_str
+        
         # Some "RPS SpA" systems are not RFC conform in this value.
         # The values can get negative but should never be.
         if power < 0:

--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -14,7 +14,7 @@ def parse_ups_power(
     string_table: list[StringTable],
 ) -> dict[str, int]:
     section: dict[str, int] = {}
-    for idx, voltage_str, power_str in string_table[0]: # pylint: disable=unused-variable
+    for idx, voltage_str, power_str in string_table[0]:  # pylint: disable=unused-variable
         try:
             power = int(power_str)
         except ValueError:

--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -19,7 +19,7 @@ def parse_ups_power(
             power = int(power_str)
         except ValueError:
             continue
-        # just to keep pylint happy, Unused variable 'voltage_str' (unused-variable) 
+        # just to keep pylint happy, Unused variable 'voltage_str' (unused-variable)
         # voltage_str could be completely removed
         voltage_str = voltage_str
 

--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -15,10 +15,10 @@ def parse_ups_power(
 ) -> dict[str, int]:
     section: dict[str, int] = {}
     for idx, voltage_str, power_str in string_table[0]:
-        if not voltage_str or not int(voltage_str):
+        try:
+            power = int(power_str)
+        except ValueError:
             continue
-
-        power = int(power_str)
         # Some "RPS SpA" systems are not RFC conform in this value.
         # The values can get negative but should never be.
         if power < 0:

--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -22,7 +22,7 @@ def parse_ups_power(
         # just to keep pylint happy, Unused variable 'voltage_str' (unused-variable) 
         # voltage_str could be completely removed
         voltage_str = voltage_str
-        
+
         # Some "RPS SpA" systems are not RFC conform in this value.
         # The values can get negative but should never be.
         if power < 0:

--- a/cmk/base/plugins/agent_based/ups_power.py
+++ b/cmk/base/plugins/agent_based/ups_power.py
@@ -14,14 +14,11 @@ def parse_ups_power(
     string_table: list[StringTable],
 ) -> dict[str, int]:
     section: dict[str, int] = {}
-    for idx, voltage_str, power_str in string_table[0]:
+    for idx, voltage_str, power_str in string_table[0]: # pylint: disable=unused-variable
         try:
             power = int(power_str)
         except ValueError:
             continue
-        # just to keep pylint happy, Unused variable 'voltage_str' (unused-variable)
-        # voltage_str could be completely removed
-        voltage_str = voltage_str
 
         # Some "RPS SpA" systems are not RFC conform in this value.
         # The values can get negative but should never be.


### PR DESCRIPTION
ups_power.py crashes if the value for power is empty.

sample crash report:

ValueError (invalid literal for int() with base 10: ‘’)

File “/omd/sites/checkmk/lib/python3/cmk/base/agent_based/data_provider.py”, line 106, in _parse_raw_data return parse_function(list(raw_data))
File “/omd/sites/checkmk/lib/python3/cmk/base/plugins/agent_based/ups_power.py”, line 22, in parse_ups_power power = int(power_str)

{‘idx’: ‘1’,
‘power_str’: ‘’,
‘section’: {},
‘string_table’: [[[‘1’, ‘122’, ‘’]]],
‘voltage_str’: ‘122’}
