### PR TITLE
FIXES: inv_if.py crashes on empty oper_status

### DIFF
--- a/cmk/base/plugins/agent_based/inv_if.py
+++ b/cmk/base/plugins/agent_based/inv_if.py
@@ -84,7 +84,7 @@ def _process_sub_table(sub_table: Sequence[str | Sequence[int]]) -> Iterable[Int
         alias=alias,
         type=type_,
         speed=int(high_speed) * 1000 * 1000 if high_speed else int(speed),
-        oper_status=int(oper_status),
+        oper_status=int(oper_status) if oper_status.isdigit() else None,
         phys_address=render_mac_address(sub_table[-2]),
         admin_status=int(admin_status) if admin_status else None,
         last_change=_process_last_change(last_change),


### PR DESCRIPTION
On some Cisco ASA/FirePower devices the `oper_status` value is empty. In this case `inv_if.py` crashes with
```
ValueError (invalid literal for int() with base 10: '')

 File "/omd/sites/build/lib/python3/cmk/base/agent_based/data_provider.py", line 106, in _parse_raw_data
    return parse_function(list(raw_data))
  File "/omd/sites/build/lib/python3/cmk/base/plugins/agent_based/inv_if.py", line 96, in parse_inv_if
    [
  File "/omd/sites/build/lib/python3/cmk/base/plugins/agent_based/inv_if.py", line 96, in <listcomp>
    [
  File "/omd/sites/build/lib/python3/cmk/base/plugins/agent_based/inv_if.py", line 87, in _process_sub_table
    oper_status=int(oper_status),
```
local Variables
```
{'admin_status': '1',
 'alias': '',
 'descr': '',
 'high_speed': '1000',
 'index': '1',
 'last_change': '0',
 'oper_status': '',
 'speed': '1000000000',
 'sub_table': ['1', '', '', '6', '1000000000', '1000', '', '1', [], '0'],
 'type_': '6'}
```
Section Content
```
[[['1', '', '', '6', '1000000000', '1000', '', '1', [], '0'],
  ['2', '', '', '6', '4294967295', '10000', '', '1', [], '1300'],
  ['3', '', '', '6', '0', '0', '', '1', [], '1300'],
  ['4', '', '', '6', '1000000000', '1000', '', '1', [], '1300'],
  ['5', '', '', '53', '1000000000', '1000', '', '1', [], '9600'],
  ['6', '', '', '53', '1000000000', '1000', '', '1', [], '9600'],
  ['7', '', '', '53', '1000000000', '1000', '', '1', [], '1300'],
  ['8', '', '', '53', '1000000000', '1000', '', '1', [], '1300'],
  ['9', '', '', '53', '1000000000', '1000', '', '1', [], '9600'],
  ['10', '', '', '53', '1000000000', '1000', '', '2', [], '1300'],
  ['11', '', '', '53', '1000000000', '1000', '', '2', [], '1300']]]
```

