### PR TITLE
FIXES: missing volumes in rstcli.py

### DIFF
--- a/cmk/base/legacy_checks/rstcli.py
+++ b/cmk/base/legacy_checks/rstcli.py
@@ -112,7 +112,7 @@ def parse_rstcli(string_table):
     volumes = {}
     for section in rstcli_sections:
         if section[0] == "VOLUME INFORMATION":
-            volumes = parse_rstcli_volumes(section[1])
+            volumes.update(parse_rstcli_volumes(section[1]))
         elif section[0].startswith("DISKS IN VOLUME"):
             volume = section[0].split(":")[1].strip()
             volumes[volume]["Disks"] = parse_rstcli_disks(section[1])


### PR DESCRIPTION
rstcli detects only one volume. It needs to update the volumes variable instead of reseting it each time.
For more details see https://forum.checkmk.com/t/monitoring-intel-vroc-with-rstcli/38613
