### PR TITLE
Update MIB for FortiAuthenicator

### DIFF
--- a/cmk/plugins/lib/fortinet.py
+++ b/cmk/plugins/lib/fortinet.py
@@ -6,6 +6,6 @@
 from cmk.agent_based.v2 import equals, startswith
 
 DETECT_FORTISANDBOX = equals(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.12356.118.1.30006")
-DETECT_FORTIAUTHENTICATOR = equals(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.8072.3.2.10")
+DETECT_FORTIAUTHENTICATOR = startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.12356.113.")
 DETECT_FORTIGATE = startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.12356.101.1.")
 DETECT_FORTIMAIL = equals(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.12356.105")


### PR DESCRIPTION
## General information

Wrong OID for detecting device - FortiAuthenticator. 
DETECT_FORTIAUTHENTICATOR = equals(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.8072.3.2.10")

1.3.6.1.4.1.8072.3.2.10 - this OID isn't for FortiAuthenticator

Your plugin https://checkmk.com/integrations/fortiauthenticator_auth_fail doesn't work. 

## Bug reports

Please include:

Ubuntu 22.04 with CheckMK 2.2

OMD[mt]:~$ snmpwalk -v2c -c **** **** .1.3.6.1.2.1.1.2.0
iso.3.6.1.2.1.1.2.0 = OID: iso.3.6.1.4.1.12356.113.100.404
OMD[mt]:~$ snmpwalk -v2c -c **** **** .1.3.6.1.4.1.12356.113.1.1
iso.3.6.1.4.1.12356.113.1.1.0 = STRING: "FAC1000D"

https://mibs.observium.org/mib/FORTINET-FORTIAUTHENTICATOR-MIB/


## Proposed changes

Change detection for FortiAuthenticator to startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.12356.113.")
