### PR TITLE
Fixed Improper Method Call: Replaced `NotImplementedError`

### DIFF
--- a/cmk/ec/forward.py
+++ b/cmk/ec/forward.py
@@ -75,7 +75,7 @@ class StructuredDataName:
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, StructuredDataName):
-            raise NotImplementedError
+            return NotImplemented
         return self.name == o.name
 
 
@@ -99,7 +99,7 @@ class StructuredDataID:
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, StructuredDataID):
-            raise NotImplementedError
+            return NotImplemented
         return self.id == o.id
 
     @staticmethod


### PR DESCRIPTION
## General information
This PR is for a normal bug fix.

## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [forward.py](https://github.com/Checkmk/checkmk/blob/master/cmk/ec/forward.py#L78), class: StructuredDataName, there is a special method `__eq__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should [return NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, [NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError) should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__eq__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is [here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).

> In file: [forward.py](https://github.com/Checkmk/checkmk/blob/master/cmk/ec/forward.py#L102), class: StructuredDataID, there is a special method `__eq__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__eq__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is here.


## Changes
Replaced occurance of `NotImplementedError` with `NotImplemented`


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
