### PR TITLE
improves Cisco Meraki device status

### DIFF
--- a/cmk/base/plugins/agent_based/cisco_meraki_org_device_status.py
+++ b/cmk/base/plugins/agent_based/cisco_meraki_org_device_status.py
@@ -1,28 +1,112 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 # Copyright (C) 2022 Checkmk GmbH - License: GNU General Public License v2
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
 
+# enhancements by thl-cmk[at]outlook[dot]com, https://thl-cmk.hopto.org
+# - made device status configurable via WATO
+# - added last_reported as check_levels, levels_upper can be configured via WATO
+# - added power supplies
+# - added unknown components (for discovery) -> removed
+# - removed device offline check from device status discovery function
+# - added power supplies to inventory (hardware -> physical components -> power supplies)
+# - changed item from "Cisco Meraki Device" Status to "Device Status" -> we know this is a Meraki device ;-)
+#
+# 2023-11-09: fixed crash if no powersupply in components
+# 2023-11-19: fixed crash in inventory if no powersupply in components
+# 2023-12-17: refactored to use pydantic
+
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Annotated, Any, Union
+
+from pydantic import BaseModel, BeforeValidator, Field
 
 from cmk.plugins.lib.cisco_meraki import check_last_reported_ts, load_json, MerakiAPIData
 
-from .agent_based_api.v1 import register, Result, Service, State
-from .agent_based_api.v1.type_defs import CheckResult, DiscoveryResult, StringTable
+from .agent_based_api.v1 import register, Result, Service, State, TableRow
+from .agent_based_api.v1.type_defs import CheckResult, DiscoveryResult, InventoryResult, StringTable
+
+# sample device status
+__device_status = [
+    {
+        "components": {
+            "powerSupplies": [
+                {
+                    "model": "PWR-MS320-250WAC",
+                    "poe": {"maximum": 0, "unit": "watts"},
+                    "serial": "Q0YY-Y0Y0-YYYY",
+                    "slot": 1,
+                    "status": "powering",
+                },
+                {
+                    "model": "PWR-MS320-250WAC",
+                    "poe": {"maximum": 0, "unit": "watts"},
+                    "serial": "Q1ZZ-Z1ZZ-ZZZZ",
+                    "slot": 2,
+                    "status": "powering",
+                },
+            ]
+        },
+        "gateway": "10.10.10.254",
+        "ipType": "static",
+        "lanIp": "10.10.10.250",
+        "lastReportedAt": "2023-12-17T09:35:08.496000Z",
+        "mac": "aa:aa:aa:aa:aa:aa",
+        "model": "MS410-16",
+        "name": "SW01",
+        "networkId": "L_012345678901234567",
+        "primaryDns": "8.8.8.8",
+        "productType": "switch",
+        "publicIp": "99.99.99.99",
+        "secondaryDns": "1.1.1.1",
+        "serial": "Q3XX-X3XX-XXX3",
+        "status": "online",
+        "tags": [],
+    }
+]
 
 
-@dataclass(frozen=True)
+class Poe(BaseModel):
+    maximum: int = Field(alias="maximum")
+    unit: str = Field(alias="unit")
+
+
+def _parse_str(raw_str: Any) -> str:
+    return str(raw_str)
+
+
+PsStr = Annotated[Union[str, None], BeforeValidator(_parse_str)]
+
+
+class PowerSupply(BaseModel):
+    slot: PsStr = Field(alias="slot")
+    model: str = Field(alias="model")
+    serial: str = Field(alias="serial")
+    status: str = Field(alias="status")
+    poe: Poe = Field(alias="poe")
+
+
+@dataclass
 class DeviceStatus:
-    status: str
-    last_reported: datetime | None
+    status: str | None = None
+    last_reported: datetime | None = None
+    power_supplies: Sequence[PowerSupply] | None = None
 
     @classmethod
     def parse(cls, row: MerakiAPIData) -> "DeviceStatus":
-        return cls(
-            status=str(row["status"]),
-            last_reported=cls._parse_last_reported(str(row["lastReportedAt"])),
-        )
+        new_cls = cls()
+        new_cls.last_reported = cls._parse_last_reported(str(row["lastReportedAt"]))
+        new_cls.status = str(row["status"])
+        new_cls.power_supplies = []
+
+        if isinstance(raw_components := row.get("components"), dict):
+            for raw_power_supply in raw_components.get("powerSupplies", []):
+                new_cls.power_supplies.append(PowerSupply.model_validate(raw_power_supply))
+
+        return new_cls
 
     @staticmethod
     def _parse_last_reported(raw_last_reported: str) -> datetime | None:
@@ -43,34 +127,123 @@ register.agent_section(
 
 
 def discover_device_status(section: DeviceStatus | None) -> DiscoveryResult:
-    if section and section.status != "offline":
+    if section:
         yield Service()
 
 
 _STATUS_MAP = {
-    "online": State.OK,
-    "alerting": State.CRIT,
-    "offline": State.WARN,
-    "dormant": State.WARN,  # TODO not sure
+    "online": State.OK.value,  # changed to int to be compatible with wato
+    "alerting": State.CRIT.value,
+    "offline": State.WARN.value,
+    "dormant": State.WARN.value,  # TODO not sure -> now configurable via WATO
 }
 
 
-def check_device_status(section: DeviceStatus | None) -> CheckResult:
+def check_device_status(params: Mapping[str, Any], section: DeviceStatus | None) -> CheckResult:
     if not section:
         return
 
+    _STATUS_MAP.update(params.get("status_map", {}))
+
     yield Result(
-        state=_STATUS_MAP.get(section.status, State.UNKNOWN),
+        state=State(_STATUS_MAP.get(str(section.status), State.CRIT.value)),
         summary=f"Status: {section.status}",
     )
 
     if section.last_reported is not None:
-        yield from check_last_reported_ts(section.last_reported.timestamp())
+        if levels_upper := params.get("last_reported_upper_levels", None):
+            warn, crit = levels_upper
+            levels_upper = (warn * 3600, crit * 3600)  # change from hours to seconds
+
+        yield from check_last_reported_ts(
+            last_reported_ts=section.last_reported.timestamp(),
+            levels_upper=levels_upper,
+            as_metric=True,
+        )
 
 
 register.check_plugin(
     name="cisco_meraki_org_device_status",
-    service_name="Cisco Meraki Device Status",
+    service_name="Device Status",
     discovery_function=discover_device_status,
     check_function=check_device_status,
+    check_default_parameters={},
+    check_ruleset_name="cisco_meraki_org_device_status",
+)
+
+
+def discover_device_status_ps(section: DeviceStatus | None) -> DiscoveryResult:
+    if not section or not section.power_supplies:
+        return
+
+    for power_supply in section.power_supplies:
+        yield Service(item=power_supply.slot)
+
+
+def check_device_status_ps(
+    item: str, params: Mapping[str, Any], section: DeviceStatus | None
+) -> CheckResult:
+    if not section or not section.power_supplies:
+        return
+
+    for power_supply in section.power_supplies:
+        if power_supply.slot == item:
+            if power_supply.status.lower() == "powering":
+                yield Result(state=State.OK, summary=f"Status: {power_supply.status}")
+            else:
+                yield Result(
+                    state=State(params.get("state_not_powering", State.WARN.value)),
+                    summary=f"Status: {power_supply.status}",
+                )
+
+            if power_supply.model:
+                yield Result(state=State.OK, notice=f"Model: {power_supply.model}")
+            if power_supply.serial:
+                yield Result(state=State.OK, notice=f"Serial: {power_supply.serial}")
+            if power_supply.poe:
+                yield Result(
+                    state=State.OK,
+                    notice=f"PoE: {power_supply.poe.maximum} {power_supply.poe.unit} maximum",
+                )
+            break
+
+
+register.check_plugin(
+    name="cisco_meraki_org_device_status_ps",
+    service_name="Power supply slot %s",
+    sections=["cisco_meraki_org_device_status"],
+    discovery_function=discover_device_status_ps,
+    check_function=check_device_status_ps,
+    check_default_parameters={},
+    check_ruleset_name="cisco_meraki_org_device_status_ps",
+)
+
+
+#
+# inventory of power supplies overview
+#
+def inventory_power_supplies(section: DeviceStatus | None) -> InventoryResult:
+    if not section or not section.power_supplies:
+        return
+
+    path = ["hardware", "components", "psus"]
+    index = 1
+    for power_supply in section.power_supplies:
+        yield TableRow(
+            path=path,
+            key_columns={"serial": power_supply.serial},
+            inventory_columns={
+                "model": power_supply.model,
+                "location": f"Slot {power_supply.slot}",
+                "index": index,
+                "manufacturer": "Cisco Meraki",
+            },
+        )
+        index += 1
+
+
+register.inventory_plugin(
+    name="cisco_meraki_power_supplies",
+    inventory_function=inventory_power_supplies,
+    sections=["cisco_meraki_org_device_status"],
 )

--- a/cmk/plugins/cisco/graphing/cisco_meraki_org_device_status.py
+++ b/cmk/plugins/cisco/graphing/cisco_meraki_org_device_status.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019 Checkmk GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+#
+# Author: thl-cmk[at]outlook[dot]com
+# URL   : https://thl-cmk.hopto.org
+# Date  : 2023-11-04
+# File  : cisco_meraki_device_status.py (metrics)
+#
+# 2023-11-12: added wireless device status (channel, channel width, signal power)
+# 2023-12-03: rewriten for garaphing api v1
+
+from cmk.graphing.v1 import Color, graph, Localizable, metric, perfometer, Unit
+
+metric_meraki_last_reported = metric.Metric(
+    name="last_reported",
+    title=Localizable("Last reported"),
+    unit=Unit.SECOND,
+    color=Color.LIGHT_GREEN,
+)
+
+graph_meraki_device_status = graph.Graph(
+    name="meraki_device_status",
+    title=Localizable("Cisco Meraki Device Last reported"),
+    compound_lines=[
+        "last_reported",
+        metric.WarningOf("last_reported"),
+        metric.CriticalOf("last_reported"),
+    ],
+    # 'range': (0, 'last_reported:max'),
+)
+
+perfometer_meraki_last_reported = perfometer.Perfometer(
+    name="meraki_last_reported",
+    focus_range=perfometer.FocusRange(
+        lower=perfometer.Closed(0), upper=perfometer.Open(7200.0)  # 2 hours
+    ),
+    segments=["last_reported"],
+)

--- a/cmk/plugins/cisco/rulesets/cisco_meraki_org_device_status.py
+++ b/cmk/plugins/cisco/rulesets/cisco_meraki_org_device_status.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019 Checkmk GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+#
+# Author: thl-cmk[at]outlook[dot]com
+# URL   : https://thl-cmk.hopto.org
+# Date  : 2023-11-04
+# File  : cisco_meraki_org_device_status.py (WATO)
+
+# 2023-12-03: moved to CMK 2.3 API v2
+# 2012-12-17: splitt device status and power supply
+
+from cmk.rulesets.v1 import (
+    CheckParameterRuleSpecWithoutItem,
+    DictElement,
+    Dictionary,
+    Integer,
+    Localizable,
+    MonitoringState,
+    State,
+    Topic,
+    Tuple,
+)
+
+
+#
+# Cisco Meraki Device Status
+#
+def _parameter_form_cisco_meraki_device_status():
+    return Dictionary(
+        elements={
+            "last_reported_upper_levels": DictElement(
+                parameter_form=Tuple(
+                    title=Localizable("Max time for last reported"),
+                    elements=[
+                        Integer(
+                            title=Localizable("Warning at"),
+                            unit=Localizable("hours"),
+                            prefill_value=2,
+                            # missing size=5 minvalue=0
+                        ),
+                        Integer(
+                            title=Localizable("Critical at"),
+                            unit=Localizable("hours"),
+                            prefill_value=3,
+                            # missing size=5 minvalue=0
+                        ),
+                    ],
+                )
+            ),
+            "status_map": DictElement(
+                parameter_form=Dictionary(
+                    title=Localizable("Map device status to monitoring state"),
+                    elements={
+                        "online": DictElement(
+                            parameter_form=MonitoringState(
+                                title=Localizable('Monitoring state for device state "online"'),
+                                prefill_value=State.OK,
+                            )
+                        ),
+                        "alerting": DictElement(
+                            parameter_form=MonitoringState(
+                                title=Localizable('Monitoring state for device state "alerting"'),
+                                prefill_value=State.CRIT,
+                            )
+                        ),
+                        "offline": DictElement(
+                            parameter_form=MonitoringState(
+                                title=Localizable('Monitoring state for device state "offline"'),
+                                prefill_value=State.WARN,
+                            )
+                        ),
+                        "dormant": DictElement(
+                            parameter_form=MonitoringState(
+                                title=Localizable('Monitoring state for device state "dormant"'),
+                                prefill_value=State.WARN,
+                            )
+                        ),
+                    },
+                )
+            ),
+        },
+    )
+
+
+rule_spec_cisco_meraki_device_status = CheckParameterRuleSpecWithoutItem(
+    name="cisco_meraki_org_device_status",
+    topic=Topic.APPLICATIONS,  # missing HARDWARE
+    # group=RulespecGroupCheckParametersHardware,
+    parameter_form=_parameter_form_cisco_meraki_device_status,
+    title=Localizable("Cisco Meraki Device status"),
+)

--- a/cmk/plugins/cisco/rulesets/cisco_meraki_org_device_status_ps.py
+++ b/cmk/plugins/cisco/rulesets/cisco_meraki_org_device_status_ps.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019 Checkmk GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+#
+# Author: thl-cmk[at]outlook[dot]com
+# URL   : https://thl-cmk.hopto.org
+# Date  : 2023-11-04
+# File  : cisco_meraki_org_device_status_ps.py (WATO)
+
+# 2023-12-03: moved to CMK 2.3 API v2
+# 2012-12-17: splitt device status and power supply
+
+
+from cmk.rulesets.v1 import (
+    CheckParameterRuleSpecWithItem,
+    DictElement,
+    Dictionary,
+    disallow_empty,
+    Localizable,
+    MonitoringState,
+    State,
+    TextInput,
+    Topic,
+)
+
+
+def _parameter_form_cisco_meraki_device_status_ps():
+    return Dictionary(
+        # title=_("Cisco Meraki Powersupply status"),
+        # optional_keys=True,
+        elements={
+            "state_not_powering": DictElement(
+                parameter_form=MonitoringState(
+                    title=Localizable('Monitoring state if power supply is not "powering"'),
+                    prefill_value=State.WARN,
+                )
+            )
+        }
+    )
+
+
+rule_spec_cisco_meraki_device_status_ps = CheckParameterRuleSpecWithItem(
+    name="cisco_meraki_org_device_status_ps",
+    topic=Topic.APPLICATIONS,  # missing HARDWARE
+    # group=RulespecGroupCheckParametersHardware,
+    item_form=TextInput(title=Localizable("The Slot number"), custom_validate=disallow_empty()),
+    parameter_form=_parameter_form_cisco_meraki_device_status_ps,
+    title=Localizable("Cisco Meraki Power supply"),
+)

--- a/cmk/plugins/collection/checkman/cisco_meraki_org_device_status_ps
+++ b/cmk/plugins/collection/checkman/cisco_meraki_org_device_status_ps
@@ -1,0 +1,17 @@
+title: Cisco Meraki devices: Power Supply
+agents: special agent
+catalog: hw/network/cisco
+license: GPLv2
+distribution: check_mk
+
+item:
+ Index of the power supply
+
+description:
+ This check monitors the health of the power supplies in Cisco Meraki devices.
+ The status of this check is translated directly from a device status.
+ "powering" is the only known state for this, which indicates a healthy PS ({OK}),
+ any other state will be treated as {WARN}.
+
+discovery:
+ One service is created for each power supply.

--- a/cmk/plugins/lib/cisco_meraki.py
+++ b/cmk/plugins/lib/cisco_meraki.py
@@ -6,8 +6,9 @@
 import json
 import time
 from collections.abc import Mapping, Sequence
+from typing import Tuple
 
-from cmk.agent_based.v2 import render, Result, State
+from cmk.agent_based.v2 import check_levels_fixed, render, Result, State
 from cmk.agent_based.v2.type_defs import CheckResult, StringTable
 
 MerakiAPIData = Mapping[str, object]
@@ -20,7 +21,9 @@ def load_json(string_table: StringTable) -> Sequence[MerakiAPIData]:
         return []
 
 
-def check_last_reported_ts(last_reported_ts: float) -> CheckResult:
+def check_last_reported_ts(
+    last_reported_ts: float, levels_upper: Tuple[int, int] | None = None, as_metric: bool = False
+) -> CheckResult:
     if (age := time.time() - last_reported_ts) < 0:
         yield Result(
             state=State.OK,
@@ -28,7 +31,10 @@ def check_last_reported_ts(last_reported_ts: float) -> CheckResult:
         )
         return
 
-    yield Result(
-        state=State.OK,
-        summary=f"Time since last report: {render.timespan(age)}",
+    yield from check_levels_fixed(
+        value=age,
+        label="Time since last report",
+        metric_name="last_reported" if as_metric else None,
+        levels_upper=levels_upper,
+        render_func=render.timespan,
     )


### PR DESCRIPTION
This PR makes better use of the data we already have.

- changes the service name from "Cisco Meraki Device Status" to "Device Status" -> we know that it is a Cisco Meraki device ;-)
- now also detects offline devices (could be made configurable via a detection rule)
- adds upper levels/metrics to the last reported time
- adds rule set for device status
- adds check for power supplies
- adds power supplies to the inventory
