### PR TITLE
Fix Zerto special agent for new Zerto verion 10.0

### DIFF
--- a/cmk/base/legacy_checks/agent_zerto.py
+++ b/cmk/base/legacy_checks/agent_zerto.py
@@ -21,6 +21,8 @@ def agent_zerto_arguments(
     return [
         "--authentication",
         params.get("authentication", "windows"),
+        "-c",
+        params.get("port"),
         "-u",
         params["username"],
         "-p",

--- a/cmk/gui/plugins/wato/special_agents/zerto.py
+++ b/cmk/gui/plugins/wato/special_agents/zerto.py
@@ -7,7 +7,7 @@
 from cmk.utils.rulesets.definition import RuleGroup
 
 from cmk.gui.i18n import _
-from cmk.gui.valuespec import Dictionary, DropdownChoice, TextInput
+from cmk.gui.valuespec import Dictionary, DropdownChoice, TextInput, Integer
 from cmk.gui.wato import MigrateToIndividualOrStoredPassword, RulespecGroupDatasourceProgramsApps
 from cmk.gui.watolib.rulespecs import HostRulespec, Rulespec, rulespec_registry
 
@@ -21,12 +21,23 @@ def _valuespec_special_agents_zerto():
     return Dictionary(
         elements=[
             (
+                "port",
+                Integer(
+                    title=_("API connection port"),
+                    label=_("port:"),
+                    minvalue=1,
+                    maxvalue=65535,
+                    default_value=9669,
+                ),
+            ),
+            (
                 "authentication",
                 DropdownChoice(
                     title=_("Authentication method"),
                     choices=[
                         ("windows", _("Windows authentication")),
                         ("vcenter", _("VCenter authentication")),
+                        ("oauth", _("OAuth2 (Keycloak) authentication")),
                     ],
                     help=_("Default is Windows authentication"),
                 ),


### PR DESCRIPTION
Hey all

We're running Zerto 10.0_U2 as an appliance and noticed that there are two changes that break the current special agent plugin:

- The API runs on port 443, however the plugin has the port 9669 hardcoded.
- They added Keycloak and Oauth2 for the authentication and removed the authentication mechanism used currently by the plugin.

Changes I impemented in the fix

* WATO-Plugin:
  * Add a third authentication option `oauth`
  * Add a field to configure the port. 9669 is still set as default to not break old setups.
* Add a `-c/--port` command line option to the special_agent and the check (`-d` was taken by passwort)
* Implement the OAuth authentication method using the public `zerto-client` clientid which is provided by default (at least it was on our appliance).

Currently I don't have access to the support portal. I will open a support request for this later, too.
