### PR TITLE
Zerto Special Agent: add missing newline

### DIFF
--- a/cmk/special_agents/agent_zerto.py
+++ b/cmk/special_agents/agent_zerto.py
@@ -118,7 +118,7 @@ def main(argv=None):
     except Exception as e:
         sys.stdout.write(f"Error: {e}")
         sys.exit(1)
-    sys.stdout.write("Initialized OK")
+    sys.stdout.write("Initialized OK\n")
 
     request = ZertoRequest(connection.base_url, session_id)
     vm_data = request.get_vms_data()


### PR DESCRIPTION
While debugging the Zerto plugin I discovered another problem which lead to the information of the first VM to be mangled with the initialization-info. The output of the plugin looked like this:

```
<<<zerto_agent:sep(0)>>>Initialized OK<<<<host1.example.com>>>>                                                                        
<<<zerto_vpg_rpo:sep(124)>>>                                                                                                    
host1|4|5                                                                                                                                                                                                                                                        
<<<<>>>>                                                                                                                        
<<<<host2.example.com>>>>                                                                                                              
<<<zerto_vpg_rpo:sep(124)>>>                                                                                                                                                                                                                                    
host2|1|5                                                                                                                       
<<<<>>>>  
```

leading to the first VM being attached to the Zerto-Host rather than piggy-backed to `host1.example.com`. Adding a newline after `Initialized OK` fixes the problem.