### PR TITLE
Requests doesn't allow anymore timeout on session

### DIFF
--- a/agents/plugins/mk_jolokia.py
+++ b/agents/plugins/mk_jolokia.py
@@ -416,7 +416,6 @@ class JolokiaInstance:
         session.verify = self._config["verify"]
         if session.verify is False:
             urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
-        session.timeout = self._config["timeout"]  # type: ignore[attr-defined]
         session.headers["User-Agent"] = user_agent
 
         auth_method = self._config.get("mode")
@@ -463,7 +462,7 @@ class JolokiaInstance:
             # Watch out: we must provide the verify keyword to every individual request call!
             # Else it will be overwritten by the REQUESTS_CA_BUNDLE env variable
             raw_response = self._session.post(
-                self.base_url, data=post_data, verify=self._session.verify
+                self.base_url, data=post_data, verify=self._session.verify, timeout=self._config["timeout"]
             )
         except requests.exceptions.ConnectionError:
             if DEBUG:


### PR DESCRIPTION

## General information
Requests doesn't allow anymore timeout on session

see 
[2856](https://github.com/psf/requests/issues/2856)
[2011](https://github.com/psf/requests/issues/2011)
currently, the post request blocks indefinitely if jolokia does not respond (python3)


## Bug reports

Please include:

+ rh7

## Proposed changes

Move timeout to the Post call instead of session.

+ What is the expected behavior?
Fall in timeout after configured timeout

+ What is the observed behavior?
the post request blocks indefinitely if jolokia does not respond (python3)
