### PR TITLE
Fixing Validation Error for ContainerWaitingState

### DIFF
--- a/cmk/special_agents/utils_kubernetes/schemata/api.py
+++ b/cmk/special_agents/utils_kubernetes/schemata/api.py
@@ -774,7 +774,7 @@ class ContainerRunningState(BaseModel):
 
 class ContainerWaitingState(BaseModel):
     type: Literal[ContainerStateType.waiting] = Field(ContainerStateType.waiting)
-    reason: str
+    reason: str | None = None
     detail: str | None = Field(None)
 
 


### PR DESCRIPTION
_General:_
Kubernetes Special Agent crashes if reason in ContainerWaitingState is None.
Affected are (at least) Rancher-Installations monitored by Checkmk via the Kubernetes-API.
Does not happen often though.

_Error message in Checkmk:_
Agent exited with code 1: 1 validation error for ContainerWaitingState
reason
none is not an allowed value (type=type_error.none.not_allowed)(!!)

_Explanation:_
Reason of ContainerWaitingState _can_ be None, e.g. when a container is in state "Terminating".

_Fix:_
Allow reason to be either str or None.