### PR TITLE
fix PowerManagement reading for latest versions of nvidia-smi

### DIFF
--- a/cmk/base/plugins/agent_based/nvidia_smi.py
+++ b/cmk/base/plugins/agent_based/nvidia_smi.py
@@ -163,7 +163,7 @@ def parse_nvidia_smi(string_table: StringTable) -> Section:
                         get_text_from_element(gpu.find("power_readings/power_state")),
                     ),
                     power_management=PowerManagement(
-                        get_text_from_element(gpu.find("power_readings/power_management"))
+                        get_text_from_element(gpu.find("power_readings/power_management")) if get_text_from_element(gpu.find("power_readings/power_management")) is not None else "Supported"
                     ),
                     power_draw=get_float_from_element(gpu.find("power_readings/power_draw"), "W"),
                     power_limit=get_float_from_element(gpu.find("power_readings/power_limit"), "W"),


### PR DESCRIPTION
## General information

This PR fixes plugin crashes with latest versions of `nvidia-smi` when having enabled the nvidia GPU monitoring accordingly because in latest versions of `nvidia-smi` the output has changed in some sections resulting in the plugin to crash accordingly.

See the following forum discussion for more information on the crash and proposed fix:
https://forum.checkmk.com/t/after-upgrade-to-2-2-0p12-parsing-of-section-nvidia-smi-failed-please-submit-a-crash-report/41979/7

## Bug reports

Please include:
+ Ubuntu Linux 22.04.3 LTS
+ CheckMk 2.2.0p21

## Proposed changes

The proposed change implements a conditional check for the PowerManagement reading section so that the corresponding `power_readings/power_management` section is checked before it is assigned to the `power_management` structure to be used later on.