### PR TITLE
Fix: Fix REDISCLI_AUTH acknowledged as own cmd by waitmax

### DIFF
--- a/agents/plugins/mk_redis
+++ b/agents/plugins/mk_redis
@@ -108,7 +108,7 @@ main() {
 
         # TODO: Use an array instead of the suppression for the command, too.
         # shellcheck disable=SC2086
-        waitmax 3 ${REDIS_CLI_COMMAND} "${REDIS_ARGS[@]}" || true
+        waitmax 3 bash -c "${REDIS_CLI_COMMAND} ${REDIS_ARGS[*]}" || true
         echo
     done
 


### PR DESCRIPTION
The command string `waitmax 3 ${REDIS_CLI_COMMAND} "${REDIS_ARGS[@]}"` results in:
> REDISCLI_AUTH='****************': No such file or directory
Fix: Hand it over to waitmax as single command via bash -c.

Using "${REDIS_ARGS[@]}" for command string concatenation results in:
> REDISCLI_AUTH='****************' redis-cli -h
only.
Fix: Use "@{REDIS_ARGS[*]}" as this transform the array into one string.

I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.