### PR TITLE
new txt mapping for PS redundancy lost

### DIFF
--- a/cmk/base/plugins/agent_based/ipmi.py
+++ b/cmk/base/plugins/agent_based/ipmi.py
@@ -268,6 +268,7 @@ def ipmi_status_txt_mapping(status_txt: str) -> State:
             "drive fault",
             "predictive failure",
             "power supply ac lost",
+            "redundancy lost",
         )
     ):
         return State.OK


### PR DESCRIPTION
Some DELL HW doesn't show correct state for PSU(s), but PS Redundancy is always correctly recognized.

 With this mapping at least the plugin raise an alert if "PS Redundancy" sensor shows "Redundancy Lost"
