### PR TITLE
Fixed local Nagvis Gadgets configuration in apache.conf

### DIFF
--- a/omd/packages/nagvis/skel/etc/nagvis/apache.conf
+++ b/omd/packages/nagvis/skel/etc/nagvis/apache.conf
@@ -9,6 +9,11 @@ Alias /###SITE###/nagvis "###ROOT###/share/nagvis/htdocs"
   Options +ExecCGI
 </Location>
 
+# Handle local Nagvis Gadgets
+<Location ~ "/###SITE###/nagvis/local/userfiles/gadgets/.*\.php$">
+  Options +ExecCGI
+</Location>
+
 # Handle locally installed files via the internal URI /###SITE###/nagvis/local
 # These files are stored below local/share/nagvis/htdocs
 <Directory ~ "###ROOT###/(share/nagvis/htdocs|tmp/nagvis/share|local/share/nagvis/htdocs)">


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Actually self created Nagvis gadgets cannot be used within Checkmk due to missing Apache configuration

## Proposed changes

Updated Nagvis apache Configuration
I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.