### PR TITLE
Fix parsing of current nvidia_smi section

### DIFF
--- a/cmk/base/plugins/agent_based/nvidia_smi.py
+++ b/cmk/base/plugins/agent_based/nvidia_smi.py
@@ -151,7 +151,7 @@ def parse_nvidia_smi(string_table: StringTable) -> Section:
     if xml.find(f"gpu/{ power_readings_element }") is None:
         power_readings_element = "power_readings"
     has_power_management = (
-        False if xml.find(f"gpu/{ power_readings_element }/power_management") is None else True
+        xml.find(f"gpu/{ power_readings_element }/power_management") is not None
     )
     return Section(
         timestamp=(

--- a/cmk/base/plugins/agent_based/nvidia_smi.py
+++ b/cmk/base/plugins/agent_based/nvidia_smi.py
@@ -146,6 +146,11 @@ def _let_pydantic_check_power_state(value: str | None) -> PowerState:
 
 def parse_nvidia_smi(string_table: StringTable) -> Section:
     xml = ElementTree.fromstring("".join([element[0] for element in string_table]))
+    # find the element name for power_readings
+    power_readings_element = "gpu_power_readings"
+    if xml.find(f"gpu/{ power_readings_element }") is None:
+        power_readings_element = "power_readings"
+    has_power_management = False if xml.find(f"gpu/{ power_readings_element }/power_management") is None else True
     return Section(
         timestamp=(
             datetime.strptime(timestamp, "%a %b %d %H:%M:%S %Y")
@@ -162,24 +167,25 @@ def parse_nvidia_smi(string_table: StringTable) -> Section:
                 product_brand=get_text_from_element(gpu.find("product_brand")),
                 power_readings=PowerReadings(
                     power_state=_let_pydantic_check_power_state(
-                        get_text_from_element(gpu.find("power_readings/power_state")),
+                        get_text_from_element(gpu.find(f"{ power_readings_element }/power_state"))
                     ),
                     power_management=PowerManagement(
-                        get_text_from_element(gpu.find("power_readings/power_management"))
+                        # assume power management is supported because newer versions of the xml don't contain it anymore
+                        get_text_from_element(gpu.find(f"{ power_readings_element }/power_management")) if has_power_management else "Supported"
                     ),
-                    power_draw=get_float_from_element(gpu.find("power_readings/power_draw"), "W"),
-                    power_limit=get_float_from_element(gpu.find("power_readings/power_limit"), "W"),
+                    power_draw=get_float_from_element(gpu.find(f"{ power_readings_element }/power_draw"), "W"),
+                    power_limit=get_float_from_element(gpu.find(f"{ power_readings_element }/power_limit"), "W"),
                     default_power_limit=get_float_from_element(
-                        gpu.find("power_readings/default_power_limit"), "W"
+                        gpu.find(f"{ power_readings_element }/default_power_limit"), "W"
                     ),
                     enforced_power_limit=get_float_from_element(
-                        gpu.find("power_readings/enforced_power_limit"), "W"
+                        gpu.find(f"{ power_readings_element }/enforced_power_limit"), "W"
                     ),
                     min_power_limit=get_float_from_element(
-                        gpu.find("power_readings/min_power_limit"), "W"
+                        gpu.find(f"{ power_readings_element }/min_power_limit"), "W"
                     ),
                     max_power_limit=get_float_from_element(
-                        gpu.find("power_readings/max_power_limit"), "W"
+                        gpu.find(f"{ power_readings_element }/max_power_limit"), "W"
                     ),
                 ),
                 temperature=Temperature(

--- a/cmk/base/plugins/agent_based/nvidia_smi.py
+++ b/cmk/base/plugins/agent_based/nvidia_smi.py
@@ -150,7 +150,9 @@ def parse_nvidia_smi(string_table: StringTable) -> Section:
     power_readings_element = "gpu_power_readings"
     if xml.find(f"gpu/{ power_readings_element }") is None:
         power_readings_element = "power_readings"
-    has_power_management = False if xml.find(f"gpu/{ power_readings_element }/power_management") is None else True
+    has_power_management = (
+        False if xml.find(f"gpu/{ power_readings_element }/power_management") is None else True
+    )
     return Section(
         timestamp=(
             datetime.strptime(timestamp, "%a %b %d %H:%M:%S %Y")
@@ -171,10 +173,18 @@ def parse_nvidia_smi(string_table: StringTable) -> Section:
                     ),
                     power_management=PowerManagement(
                         # assume power management is supported because newer versions of the xml don't contain it anymore
-                        get_text_from_element(gpu.find(f"{ power_readings_element }/power_management")) if has_power_management else "Supported"
+                        get_text_from_element(
+                            gpu.find(f"{ power_readings_element }/power_management")
+                        )
+                        if has_power_management
+                        else "Supported"
                     ),
-                    power_draw=get_float_from_element(gpu.find(f"{ power_readings_element }/power_draw"), "W"),
-                    power_limit=get_float_from_element(gpu.find(f"{ power_readings_element }/power_limit"), "W"),
+                    power_draw=get_float_from_element(
+                        gpu.find(f"{ power_readings_element }/power_draw"), "W"
+                    ),
+                    power_limit=get_float_from_element(
+                        gpu.find(f"{ power_readings_element }/power_limit"), "W"
+                    ),
                     default_power_limit=get_float_from_element(
                         gpu.find(f"{ power_readings_element }/default_power_limit"), "W"
                     ),

--- a/cmk/base/plugins/agent_based/nvidia_smi.py
+++ b/cmk/base/plugins/agent_based/nvidia_smi.py
@@ -150,9 +150,7 @@ def parse_nvidia_smi(string_table: StringTable) -> Section:
     power_readings_element = "gpu_power_readings"
     if xml.find(f"gpu/{ power_readings_element }") is None:
         power_readings_element = "power_readings"
-    has_power_management = (
-        xml.find(f"gpu/{ power_readings_element }/power_management") is not None
-    )
+    has_power_management = xml.find(f"gpu/{ power_readings_element }/power_management") is not None
     return Section(
         timestamp=(
             datetime.strptime(timestamp, "%a %b %d %H:%M:%S %Y")


### PR DESCRIPTION
## General information
The XML output of current nvidia-smi commands contain two changes:
1. `power_readings` was renamed to `gpu_power_readings`
2. `power_management` was removed

You can find an example of the recent XML in https://github.com/influxdata/telegraf/issues/13653

## Bug reports

Section parsing for nvidia_smi fails because it cannot find some expected elements in recent versions of the nvidia-smi output.

## Proposed changes

This is an imroved version of PR #669

+ What is the expected behavior?
Section can be parsed
+ What is the observed behavior?
Section parsing crashes because it cannot find some XML elements
+ If it's not obvious from the above: In what way does your patch change the current behavior?
The PR checks if an XML element with the new name `gpu_power_readings` exists. If not it fails back to the old element name `power_readings`.
For the element `power_management` that has been removed it checks if it exists. If not it assumes a default of "Supported"

I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.