### PR TITLE
Fix redis warning

### DIFF
--- a/omd/packages/redis/skeleton/etc/redis/redis.conf
+++ b/omd/packages/redis/skeleton/etc/redis/redis.conf
@@ -26,3 +26,11 @@ maxclients 512
 
 # TCP backlog setting
 tcp-backlog 128
+
+### remove redis Warnings about
+# WARNING overcommit_memory is set to 0! Background save may fail
+# under low memory condition. To fix this issue add
+# 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or
+# run the command 'sysctl -w vm.overcommit_memory=1' for this to take
+# effect.
+vm.overcommit_memory=1


### PR DESCRIPTION
When Checkmk starts, there is the following warning in `~/var/log/redis-server.log`:

```
WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl -w vm.overcommit_memory=1' for this to take effect.
```