### PR TITLE
MS SQL data file calculation mapping correct mount points not only dr…

### DIFF
--- a/cmk/base/plugins/agent_based/mssql_datafiles_transactionlogs.py
+++ b/cmk/base/plugins/agent_based/mssql_datafiles_transactionlogs.py
@@ -66,7 +66,7 @@ def parse_mssql_datafiles(string_table: StringTable) -> SectionDatafiles:
                 "max_size": None,
                 "allocated_size": None,
                 "used_size": None,
-                "mountpoint": physical_name[0],
+                "mountpoint": physical_name.lower(),
             },
         )
         with suppress(ValueError):
@@ -178,6 +178,18 @@ def _mssql_datafiles_process_sizes(
         summary=f"Maximum size: {render.bytes(datafile_usage.max)}",
     )
 
+def _get_mountpoint(
+    df_dict: dict,
+    physical_name: str,
+) -> str:
+    part = physical_name.split("\\")
+    i = len(part)
+    while i > 1:
+        i = i -1
+        mountpoint = df_dict.get("/".join(part[0:i])+"/")
+        if mountpoint is not None:
+            return "/".join(part[0:i])+"/"
+    return part[0]+"/"
 
 def discover_mssql_common(
     mode: Literal["datafiles", "transactionlogs"],
@@ -225,15 +237,20 @@ def _datafile_usage(
     used_size_sum = 0.0
     unlimited = False
     instances_found = False
+    used_mointpoints = []
 
     for instance in instances:
         instances_found = True
         unlimited |= instance["unlimited"]
         allocated_size_sum += instance["allocated_size"] or 0
         used_size_sum += (used_size := instance["used_size"] or 0)
+        mountpoint = _get_mountpoint(available_bytes, instance["mountpoint"])
+        filesystem_free_size = available_bytes.get(mountpoint)
+        if mountpoint in used_mointpoints:filesystem_free_size = 0
+        else: used_mointpoints.append(mountpoint)
         max_size = _effective_max_size(
             instance["max_size"],
-            available_bytes.get(instance["mountpoint"]),
+            filesystem_free_size,
             used_size,
             unlimited,
         )
@@ -284,7 +301,7 @@ def check_mssql_common(
         )
     )
     available_bytes = (
-        {f.mountpoint[0]: f.avail_mb * 1024 * 1024 for f in section_df[0]} if section_df else {}
+        {f.mountpoint.lower(): f.avail_mb * 1024 * 1024 for f in section_df[0]} if section_df else {}
     )
 
     if not (


### PR DESCRIPTION
## General information

This affects MS SQL Database Files and Transaction log monitoring 
+ if the Windows Server uses mountpoints. 
+ if the 'MSSQL datafile and transactionlog discovery' ruset is used to crate a summary of all Database Files

The Plugin currently only works correctly for systems without mountpoints.


## Bug reports

+ Your operating system name and version
+ => Windows Server 2012 R2 to 2022 (MSSQL 2014-2022)
+ Any details about your local setup that might be helpful in troubleshooting
+ => MSSQL Setup with multiple Database Files on mount points
+ Detailed steps to reproduce the bug:

Example section:
```
<<<df:sep(9)>>>
System	NTFS	125247484	83827900	41419584	67%	C:\
SQL_root	NTFS	104724416	31955520	72768896	31%	D:\
SHARED01_dta	NTFS	1047233920	457569280	589664640	44%	D:\CusDTA\
SHARED01_log	NTFS	83751872	36375296	47376576	44%	D:\CusLOG\
temp	NTFS	10485760	375296	10110464	3%	D:\temp\
<<<mssql_datafiles:sep(124)>>>
SHARED01|master|master1|D:\CusDTA\master1.mdf|0|124890|124172|1
SHARED01|master|master2|D:\CusDTA\master2.mdf|0|128890|128172|1
<<<mssql_transactionlogs:sep(124)>>>
SHARED01|master|masterlog1|D:\CusLOG\masterlog1.ldf|1000|5|1|1
SHARED01|master|masterlog2|D:\CusLOG\masterlog2.ldf|1500|5|1|1
```

Enable the Ruleset 'MSSQL data file and transaction log discovery'

## Proposed changes
My changes to the plugin are:
1. changed the available bytes part to preserve all mount points
- currently, the last mount point sets the available bytes for the drive letter
=> in my example without my change, this means the "D:\temp" would be used for all calculations
2. added a function to get the mount point / drive letter for each file (_get_mountpoint)
3. implemented the _get_mountpoint function to get the right mount point
4. only add the free size of a mount point once in summary mode
- when to files are on the same mount point and both are unlimited, the plugin adds the free space for each file
=> in my example without my change, this would result in adding the "D:\temp\" free space twice