### PR TITLE
MSSQL Databases Recovery Model check

### DIFF
--- a/cmk/gui/plugins/wato/check_parameters/mssql_databases.py
+++ b/cmk/gui/plugins/wato/check_parameters/mssql_databases.py
@@ -9,7 +9,7 @@ from cmk.gui.plugins.wato.utils import (
     rulespec_registry,
     RulespecGroupCheckParametersApplications,
 )
-from cmk.gui.valuespec import Dictionary, MonitoringState, TextInput
+from cmk.gui.valuespec import Dictionary, DropdownChoice, MonitoringState, TextInput
 
 
 def _parameter_valuespec_mssql_databases():
@@ -56,7 +56,26 @@ def _parameter_valuespec_mssql_databases():
                     optional_keys=[],
                 ),
             ),
+            (
+                "recovery_model",
+                DropdownChoice(
+                    title=_("Setting a specific recovery model for the database"),
+                    choices=[
+                        ("FULL", _("Full")),
+                        ("SIMPLE", _("Simple")),
+                        ("BULK-LOGGED", _("Bulk-logged")),
+                    ],
+                ),
+            ),
+            (
+                "if_not_reco_model",
+                MonitoringState(
+                    title=_("Criticality if not choosen Recovery Model is not set"),
+                    default_value=1,
+                ),
+            ),
         ],
+        optional_keys=["recovery_model", "if_not_reco_model"],
     )
 
 

--- a/cmk/plugins/mssql/agent_based/mssql_databases.py
+++ b/cmk/plugins/mssql/agent_based/mssql_databases.py
@@ -86,6 +86,15 @@ def check_mssql_databases(
         return
     state_int = params.get("map_db_states", {}).get(db_state.replace(" ", "_").upper(), 0)
     yield Result(state=State(state_int), summary="Status: %s" % db_state)
+    if should_be_reco_model := params.get("recovery_model"):
+        if should_be_reco_model == data["Recovery"]:
+            yield Result(state=State.OK, summary="Recovery: %s" % data["Recovery"])
+        else:
+            yield Result(
+                state=State(params["if_not_reco_model"]),
+                summary=f"Recovery: {data['Recovery']} (but should {should_be_reco_model})",
+            )
+
     yield Result(state=State.OK, summary="Recovery: %s" % data["Recovery"])
 
     for what in ["close", "shrink"]:
@@ -110,7 +119,7 @@ check_plugin_mssql_databases = CheckPlugin(
     service_name="MSSQL %s Database",
     discovery_function=discover_mssql_databases,
     check_function=check_mssql_databases,
-    check_default_parameters={},
+    check_default_parameters={"if_not_reco_model": 1},
     check_ruleset_name="mssql_databases",
     cluster_check_function=cluster_check_mssql_databases,
 )


### PR DESCRIPTION
This extension can be used to check the specific recovery model of the MSSQL database.
I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.