### PR TITLE
If VMWare PowerCLI Module is installed, call of Get-VM fails

### DIFF
--- a/agents/windows/plugins/hyperv_vms.ps1
+++ b/agents/windows/plugins/hyperv_vms.ps1
@@ -1,4 +1,4 @@
 $CMK_VERSION = "2.3.0b1"
 Write-Host "<<<hyperv_vms:sep(9)>>>"
 
-Get-VM | select Name, State, Uptime, Status | ConvertTo-Csv -Delimiter "`t" -NoTypeInformation
+Hyper-V\Get-VM | select Name, State, Uptime, Status | ConvertTo-Csv -Delimiter "`t" -NoTypeInformation


### PR DESCRIPTION
**Problem**
The problem occurs when the VMWare PowerCLI module is also installed on a system. In this case, calling the Get-VM cmdlet leads to the following error:

`Get-VM You are not currently connected to any servers. Please connect first using a Connect cmdlet.`

**Reason**
The reason is that the Get-VM cmdlet of the PowerCLI module is incorrectly used because there is an overlap in the naming of the Hyper-V cmdlet and the PowerCLI cmdlet.

**Solution**
The solution to this is to specify the name of the cmdlet absolutely: Hyper-V\Get-VM instead of Get-VM