### PR TITLE
 Support freebsd (OPNsense etc) for the included plugin isc_dhcpd

### DIFF
--- a/agents/plugins/isc_dhcpd.py
+++ b/agents/plugins/isc_dhcpd.py
@@ -15,7 +15,11 @@ import sys
 import time
 
 conf_file = None
-for path in ["/etc/dhcpd.conf", "/etc/dhcp/dhcpd.conf", "/var/dhcpd/etc/dhcpd.conf", "/usr/local/etc/dhcpd.conf"]:
+for path in ["/etc/dhcpd.conf", 
+             "/etc/dhcp/dhcpd.conf", 
+             "/var/dhcpd/etc/dhcpd.conf", 
+             "/usr/local/etc/dhcpd.conf",
+            ]:
     if os.path.exists(path):
         conf_file = path
         break

--- a/agents/plugins/isc_dhcpd.py
+++ b/agents/plugins/isc_dhcpd.py
@@ -15,7 +15,8 @@ import sys
 import time
 
 conf_file = None
-for path in ["/etc/dhcpd.conf", 
+for path in [
+             "/etc/dhcpd.conf", 
              "/etc/dhcp/dhcpd.conf", 
              "/var/dhcpd/etc/dhcpd.conf", 
              "/usr/local/etc/dhcpd.conf",

--- a/agents/plugins/isc_dhcpd.py
+++ b/agents/plugins/isc_dhcpd.py
@@ -16,9 +16,9 @@ import time
 
 conf_file = None
 for path in [
-    "/etc/dhcpd.conf", 
-    "/etc/dhcp/dhcpd.conf", 
-    "/var/dhcpd/etc/dhcpd.conf", 
+    "/etc/dhcpd.conf",
+    "/etc/dhcp/dhcpd.conf",
+    "/var/dhcpd/etc/dhcpd.conf",
     "/usr/local/etc/dhcpd.conf",
 ]:
     if os.path.exists(path):

--- a/agents/plugins/isc_dhcpd.py
+++ b/agents/plugins/isc_dhcpd.py
@@ -16,11 +16,11 @@ import time
 
 conf_file = None
 for path in [
-             "/etc/dhcpd.conf", 
-             "/etc/dhcp/dhcpd.conf", 
-             "/var/dhcpd/etc/dhcpd.conf", 
-             "/usr/local/etc/dhcpd.conf",
-            ]:
+    "/etc/dhcpd.conf", 
+    "/etc/dhcp/dhcpd.conf", 
+    "/var/dhcpd/etc/dhcpd.conf", 
+    "/usr/local/etc/dhcpd.conf",
+]:
     if os.path.exists(path):
         conf_file = path
         break

--- a/agents/plugins/isc_dhcpd.py
+++ b/agents/plugins/isc_dhcpd.py
@@ -25,6 +25,7 @@ for path in [
     "/var/lib/dhcp/db/dhcpd.leases",
     "/var/lib/dhcp/dhcpd.leases",
     "/var/lib/dhcpd/dhcpd.leases",  # CentOS
+    "/var/dhcpd/var/db/dhcpd.leases", # OPNsense
 ]:
     if os.path.exists(path):
         leases_file = path
@@ -43,6 +44,10 @@ def get_pid():
         # workaround for bug in sysvinit-utils in debian buster
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926896
         cmd = "ps aux | grep -w [d]hcpd | awk {'printf (\"%s \", $2)'}"
+
+    if "freebsd" in platform.platform().lower():
+        # workaround for freebsd
+        cmd = "ps aux | grep -w \"[d]hcpd\" | awk '{print $2}'"
 
     # This produces a false warning in Bandit, claiming there was no failing test for this nosec.
     # The warning is a bug in Bandit: https://github.com/PyCQA/bandit/issues/942

--- a/agents/plugins/isc_dhcpd.py
+++ b/agents/plugins/isc_dhcpd.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 conf_file = None
-for path in ["/etc/dhcpd.conf", "/etc/dhcp/dhcpd.conf", "/usr/local/etc/dhcpd.conf"]:
+for path in ["/etc/dhcpd.conf", "/etc/dhcp/dhcpd.conf", "/var/dhcpd/etc/dhcpd.conf", "/usr/local/etc/dhcpd.conf"]:
     if os.path.exists(path):
         conf_file = path
         break
@@ -25,7 +25,7 @@ for path in [
     "/var/lib/dhcp/db/dhcpd.leases",
     "/var/lib/dhcp/dhcpd.leases",
     "/var/lib/dhcpd/dhcpd.leases",  # CentOS
-    "/var/dhcpd/var/db/dhcpd.leases", # OPNsense
+    "/var/dhcpd/var/db/dhcpd.leases",  # OPNsense
 ]:
     if os.path.exists(path):
         leases_file = path


### PR DESCRIPTION
Support freebsd (OPNsense etc)

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

This is to make the isc_dhcpd plugin work with any recent version of [OPNsense](https://github.com/opnsense).

## Proposed changes

The `dhcpd.leases` file is in a different location than expected by the script. The command `pidof` doesn't exist and `awk` is also more limited.

```bash
root@OPNsense:~ # awk --version
awk version 20210215
```
This PR could be improved, using a configuration file instead of hardcoding the necessary files would be good. Also, for the `pidof` problem, `which pidof` could be used before falling back to something more universal with `ps`.

I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.