### PR TITLE
Fix conversion from ms/s to % in jvm_gc (Garbage collector for Jolokia)

### DIFF
--- a/cmk/base/legacy_checks/jolokia_jvm_garbagecollectors.py
+++ b/cmk/base/legacy_checks/jolokia_jvm_garbagecollectors.py
@@ -81,7 +81,7 @@ def check_jolokia_jvm_garbagecollectors(item, params, parsed):
     )
 
     yield check_levels(
-        ctime_rate * 10.0,  # ms/s -> %
+        ctime_rate * 0.1,  # ms/s -> %
         "jvm_garbage_collection_time",
         params.get("collection_time"),
         unit="%",


### PR DESCRIPTION
Reopen [695](https://github.com/Checkmk/checkmk/pull/695)

General information
Metrics Collection_time is not correctly computed (by a factor 100)

Bug reports
Please include:

Your operating system name and version
RH8

Proposed changes
it should not be multiply by 10, but divide by 10 to get percent

We got a ctime rate express in ms/s
250ms/s = 25% not 2500%

See [forum](https://forum.checkmk.com/t/weird-values-for-gc-ps-marksweep-time-collecting-garbage/46738/5) 
