### PR TITLE
fix mk_docker.py to not crash if dev is missing

### DIFF
--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -294,8 +294,9 @@ class MKDockerClient(docker.DockerClient):  # type: ignore[misc]
 
             self._device_map = {}
             for device in os.listdir("/sys/block"):
-                with open("/sys/block/%s/dev" % device) as handle:
-                    self._device_map[handle.read().strip()] = device
+                if os.path.exists("/sys/block/%s/dev" % device):
+                    with open("/sys/block/%s/dev" % device) as handle:
+                        self._device_map[handle.read().strip()] = device
 
         return self._device_map
 


### PR DESCRIPTION
**This is a resubmit of PR #670 after all the force-rebased mess in the master branch**

## General information

This PR is fixing a minor issue in `mk_docker.py` which causes it to crash if the `/sys/block/<device>/dev` path does not exist.

In some environment (e.g. with NVMe drives), this plugin can return the following exception:

```
Plugin exception in section_container_diskstat: [Errno 2] No such file or directory: '/sys/block/nvme0c0n1/dev'
```

This is the result of a missing exists check of that very `/sys/block/<device>/dev` in `mk_docker.py` because it is not guaranteed that in the corresponding environment that `dev` path actually exists. Thus, `mk_docker.py` will still add that device node to the internal device map and then runs into the above mentioned exception.

See here for the corresponding OS output when try to access this device node on the command-line while the complete device block directory shows a normal path:

```
$ ls -la /sys/block/nvme0c0n1/dev
ls: cannot access '/sys/block/nvme0c0n1/dev': No such file or directory
$ ls -la /sys/block/nvme0c0n1/
total 0
drwxr-xr-x 9 root root    0 Feb  7 09:10 .
drwxr-xr-x 5 root root    0 Feb  7 09:10 ..
-r--r--r-- 1 root root 4096 Feb  7 10:26 alignment_offset
-r--r--r-- 1 root root 4096 Feb  7 10:26 capability
lrwxrwxrwx 1 root root    0 Feb  7 10:26 device -> ../../nvme0
-r--r--r-- 1 root root 4096 Feb  7 10:26 discard_alignment
-r--r--r-- 1 root root 4096 Feb  7 10:26 diskseq
-r--r--r-- 1 root root 4096 Feb  7 10:26 eui
-r--r--r-- 1 root root 4096 Feb  7 10:26 events
-r--r--r-- 1 root root 4096 Feb  7 10:26 events_async
-rw-r--r-- 1 root root 4096 Feb  7 10:26 events_poll_msecs
-r--r--r-- 1 root root 4096 Feb  7 10:26 ext_range
-r--r--r-- 1 root root 4096 Feb  7 09:10 hidden
drwxr-xr-x 2 root root    0 Feb  7 10:26 holders
-r--r--r-- 1 root root 4096 Feb  7 10:26 inflight
drwxr-xr-x 2 root root    0 Feb  7 10:26 integrity
drwxr-xr-x 5 root root    0 Feb  7 10:26 mq
-r--r--r-- 1 root root 4096 Feb  7 10:26 nsid
drwxr-xr-x 2 root root    0 Feb  7 10:26 power
drwxr-xr-x 2 root root    0 Feb  7 10:26 queue
-r--r--r-- 1 root root 4096 Feb  7 10:26 range
-r--r--r-- 1 root root 4096 Feb  7 10:26 removable
-r--r--r-- 1 root root 4096 Feb  7 10:26 ro
-r--r--r-- 1 root root 4096 Feb  7 10:26 size
drwxr-xr-x 2 root root    0 Feb  7 10:26 slaves
-r--r--r-- 1 root root 4096 Feb  7 10:26 stat
lrwxrwxrwx 1 root root    0 Feb  7 10:26 subsystem -> ../../../../../../../class/block
drwxr-xr-x 2 root root    0 Feb  7 10:26 trace
-rw-r--r-- 1 root root 4096 Feb  7 10:26 uevent
-r--r--r-- 1 root root 4096 Feb  7 10:26 wwid

```

This PR solves this issue by adding a simply `os.path.exists()` check to first check if the device node really exists and only adds that device to the device map in case it exists. Thus, the exception is then solved.

## Bug reports

Please include:

+ Ubuntu Linux 22.04.3 LTS
+ CheckMK 2.2.0p21

## Proposed changes

Add the mentioned `os.path.exists()` should fix the issue for these rare cases where `mk_docker.py` might try to pickup a device which does not have a `dev` folder/path in the `/sys/block` path.