### PR TITLE
check_mk_agent: Do not rely on "hostname" cmd on OpenWRT

### DIFF
--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -272,7 +272,7 @@ section_checkmk() {
     echo "<<<check_mk>>>"
     echo "Version: 2.4.0b1"
     echo "AgentOS: openwrt"
-    echo "Hostname: $(hostname)"
+    echo "Hostname: $(cat /proc/sys/kernel/hostname)"
     echo "AgentDirectory: ${MK_CONFDIR}"
     echo "DataDirectory: ${MK_VARDIR}"
     echo "SpoolDirectory: ${SPOOLDIR}"
@@ -866,7 +866,7 @@ section_veritas_vcs() {
     # Secure mode must be off to allow root to execute commands
     if [ -x /opt/VRTSvcs/bin/haclus ]; then
         echo "<<<veritas_vcs>>>"
-        vcshost=$(hostname | cut -d. -f1)
+        vcshost=$(cat /proc/sys/kernel/hostname | cut -d. -f1)
         waitmax -s 9 2 /opt/VRTSvcs/bin/haclus -display -localclus | grep -e ClusterName -e ClusState
         waitmax -s 9 2 /opt/VRTSvcs/bin/hasys -display -attribute SysState
         waitmax -s 9 2 /opt/VRTSvcs/bin/hagrp -display -sys "${vcshost}" -attribute State -localclus


### PR DESCRIPTION
**Issue:**

Built-in BusyBox shell in OpenWRT has no `hostname` command available by default. While it can be added with additional packages in custom images there are alternative ways to determine the machine's hostname without introducing an additional dependency.

On some default OpenWRT image the "Hostname" attribute is empty:
```
root@my-openwrt-box:~# hostname
-ash: hostname: not found

root@my-openwrt-box:~# cat /proc/sys/kernel/hostname
my-openwrt-box

root@my-openwrt-box:~# check_mk_agent dump
<<<check_mk>>>
Version: 2.2.0p26
AgentOS: openwrt
Hostname: 
AgentDirectory: /etc/check_mk
...
```

Well, it doesn't really hurt much, but it's not desired behavior either.

**Proposed changes:**

Read the hostname from the sysctl parameter kernel.hostname (i.e. read /proc/sys/kernel/hostname) instead which is likely available on every image.

```
root@my-openwrt-box:~# check_mk_agent dump

<<<check_mk>>>
Version: 2.2.0p26
AgentOS: openwrt
Hostname: my-openwrt-box
AgentDirectory: /etc/check_mk
...
```