### PR TITLE
Add sysctl_mem option for FreeBSD

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -597,6 +597,21 @@ run_purely_synchronous_sections() {
 
         rm -f "${tmpfile}"
     fi
+
+    echo '<<<sysctl_mem>>>'
+    _page_size=$( sysctl -n vm.stats.vm.v_page_size )
+    echo "mem.cache $(( _page_size * $( sysctl -n vm.stats.vm.v_cache_count ) ))"
+    echo "mem.free $(( _page_size * $( sysctl -n vm.stats.vm.v_free_count ) ))"
+    echo "mem.total $( sysctl -n hw.physmem )"
+    echo "mem.used $(( _page_size * ( $( sysctl -n vm.stats.vm.v_active_count ) + $( sysctl -n vm.stats.vm.v_wire_count ) ) ))"
+    _swap_total=$( sysctl -n vm.swap_total )
+    _swap_used=$(( $( swapinfo | tail -1 | awk '{print $3}' ) * 1024 ))
+    echo "swap.free $(( _swap_total - _swap_used ))"
+    echo "swap.total ${_swap_total}"
+    echo "swap.used ${_swap_used}"
+    unset -v _page_size
+    unset -v _swap_total
+    unset -v _swap_used
 }
 
 #

--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -364,6 +364,24 @@ section_fileinfo() {
     ' -- "${MK_CONFDIR}"
 }
 
+section_sysctlmem() {
+    # Output FreeBSD memory info from sysctl
+    echo '<<<sysctl_mem>>>'
+    _page_size=$( sysctl -n vm.stats.vm.v_page_size )
+    echo "mem.cache $(( _page_size * $( sysctl -n vm.stats.vm.v_cache_count ) ))"
+    echo "mem.free $(( _page_size * $( sysctl -n vm.stats.vm.v_free_count ) ))"
+    echo "mem.total $( sysctl -n vm.kmem_size )"
+    echo "mem.used $(( _page_size * ( $( sysctl -n vm.stats.vm.v_active_count ) + $( sysctl -n vm.stats.vm.v_wire_count ) ) ))"
+    _swap_total=$( sysctl -n vm.swap_total )
+    _swap_used=$(( $( swapinfo | tail -1 | awk '{print $3}' ) * 1024 ))
+    echo "swap.free $(( _swap_total - _swap_used ))"
+    echo "swap.total ${_swap_total}"
+    echo "swap.used ${_swap_used}"
+    unset -v _page_size
+    unset -v _swap_total
+    unset -v _swap_used
+}
+
 #
 # END COMMON AGENT CODE
 #
@@ -375,6 +393,8 @@ run_purely_synchronous_sections() {
     section_cmk_agent_ctl_status
 
     section_checkmk_agent_plugins
+
+    section_sysctlmem
 
     osver="$(uname -r)"
     is_jailed="$(sysctl -n security.jail.jailed)"
@@ -597,21 +617,6 @@ run_purely_synchronous_sections() {
 
         rm -f "${tmpfile}"
     fi
-
-    echo '<<<sysctl_mem>>>'
-    _page_size=$( sysctl -n vm.stats.vm.v_page_size )
-    echo "mem.cache $(( _page_size * $( sysctl -n vm.stats.vm.v_cache_count ) ))"
-    echo "mem.free $(( _page_size * $( sysctl -n vm.stats.vm.v_free_count ) ))"
-    echo "mem.total $( sysctl -n hw.physmem )"
-    echo "mem.used $(( _page_size * ( $( sysctl -n vm.stats.vm.v_active_count ) + $( sysctl -n vm.stats.vm.v_wire_count ) ) ))"
-    _swap_total=$( sysctl -n vm.swap_total )
-    _swap_used=$(( $( swapinfo | tail -1 | awk '{print $3}' ) * 1024 ))
-    echo "swap.free $(( _swap_total - _swap_used ))"
-    echo "swap.total ${_swap_total}"
-    echo "swap.used ${_swap_used}"
-    unset -v _page_size
-    unset -v _swap_total
-    unset -v _swap_used
 }
 
 #


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

This rework from Brad works on PR#578 and new PR from #696, with Allan suggestions.


## Proposed changes

Making a `sysctl_mem` option per default.
This permit to have information using sysctl information in addition of other way to have this.
Since sysctl is always present on FreeBSD this information is alway given.

We should have a new section giving the following informations:

```
<<<sysctl_mem>>>
mem.cache 0
mem.free 188102864896
mem.total 274779779072
mem.used 79134859264
swap.free 8589934592
swap.total 8589934592
swap.used 0
```

Kind regards