### PR TITLE
make mysql capacity check optional

### DIFF
--- a/agents/plugins/mk_mysql
+++ b/agents/plugins/mk_mysql
@@ -30,11 +30,13 @@ do_query() {
     mysql --defaults-file="$MK_CONFDIR"/mysql.cfg ${1:+--socket="$1"} -sN \
         -e "show global status ; show global variables ;"
 
-    echo "<<<mysql_capacity>>>"
-    echo "$INSTANCE_HEADER"
-    mysql --defaults-file="$MK_CONFDIR"/mysql.cfg ${1:+--socket="$1"} -sN \
-        -e "SELECT table_schema, sum(data_length + index_length), sum(data_free)
-            FROM information_schema.TABLES GROUP BY table_schema"
+    if [ ! -f "${MK_CONFDIR}/mysql.local.disable_capacity_checks" ]; then
+        echo "<<<mysql_capacity>>>"
+        echo "$INSTANCE_HEADER"
+        mysql --defaults-file="$MK_CONFDIR"/mysql.cfg ${1:+--socket="$1"} -sN \
+            -e "SELECT table_schema, sum(data_length + index_length), sum(data_free)
+                FROM information_schema.TABLES GROUP BY table_schema"
+    fi
 
     echo "<<<mysql_slave>>>"
     echo "$INSTANCE_HEADER"


### PR DESCRIPTION
## General information

on a shared hosting server we found the capacity check was adding extreme amounts of load to our MySQL server. it was also causing the checkmk agent to not respond in time (per https://forum.checkmk.com/t/cmk-agent-connection-ok-dump-has-no-output/38598)

timed dump command before disabling the mysql_capacity check
`time cmk-agent-ctl dump`

```
real	2m3.968s
user	0m0.002s
sys	0m0.006s
```

timed dump after disabling the mysql_capacity check
```
real	0m15.227s
user	0m0.002s
sys	0m0.013s
```
## Proposed changes

This change makes it possible to easily disable the capacity checks by creating a local file at `${MK_CONFDIR}/mysql.local.disable_capacity_checks` 
The existing usecase will not change at all if the file does not exist.
