### PR TITLE
Fix wrong backup check for SQL Always on High availability Groups

### DIFF
--- a/agents/windows/plugins/mssql.vbs
+++ b/agents/windows/plugins/mssql.vbs
@@ -726,7 +726,7 @@ For Each instance_id In instances.Keys: Do ' Continue trick
                     "LEFT OUTER JOIN sys.databases db ON b.database_name = db.name  " & _
                     "LEFT OUTER JOIN sys.dm_hadr_database_replica_states rep ON db.database_id = rep.database_id  " & _
                     "WHERE (rep.is_local is null or rep.is_local = 1)  " & _
-                    "AND (rep.is_primary_replica is null or rep.is_primary_replica = ''True'') and machine_name = SERVERPROPERTY(''Machinename'') " & _
+                    "AND machine_name = SERVERPROPERTY(''Machinename'') " & _
                     "GROUP BY type, rep.replica_id, rep.is_primary_replica, rep.is_local, b.database_name, b.machine_name, rep.synchronization_state, rep.synchronization_health' " & _
                 "END " & _
                 "EXEC (@SQLCommand)"
@@ -754,7 +754,7 @@ For Each instance_id In instances.Keys: Do ' Continue trick
                is_primary_replica = Trim(record("is_primary_replica"))
                backup_machine_name = Trim(record("machine_name"))
 
-               If lastBackupDate <> "" and (replica_id = "" or is_primary_replica = "True") Then
+               If lastBackupDate <> "" Then
                    addOutput("MSSQL_" & instance_id & "|" & backup_database & _
                              "|" & Replace(lastBackupDate, " ", "|") & "|" & backup_type)
                End If


### PR DESCRIPTION
This is a recreation of https://github.com/Checkmk/checkmk/pull/518
## Bug reports
 **operating system name and version**
SQL Always on High availability Groups on SQL Server 2019
Windows Server 2019
**Detailed steps to reproduce the bug**
1. Create a Backup of a High Available Database on Server1
2. Move the Database to Server2
3. You get a backup Error because no actual backup is found
## Proposed changes

**What is the expected behavior?**
The Agent should return the Backup status, even if it is not the primary Server
**What is the observed behavior?**
The Agent does not return the Backup if it is not the Primary Replica
**If it's not obvious from the above: In what way does your patch change the current behavior?**
The Primary Server check is removed
**Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?**
The move of the database.
