### PR TITLE
BUG: Nutanix fix for wrong section name from special agent after last commits

### DIFF
--- a/cmk/plugins/prism/agent_based/prism_info.py
+++ b/cmk/plugins/prism/agent_based/prism_info.py
@@ -40,8 +40,9 @@ def host_label_prism_info(section: Section) -> HostLabelGenerator:
 
 
 agent_section_prism_info = AgentSection(
-    name="prism_info",
+    name="prism_cluster",
     parse_function=parse_prism_info,
+    parsed_section_name="prism_info",
     host_label_function=host_label_prism_info,
 )
 


### PR DESCRIPTION
## General information

Nutanix Cluster checks are getting no data as the section providing the data changed names after the last commit
https://github.com/Checkmk/checkmk/commit/3faacc012ca9ad8e66285ce62d221e79df56e43c
before --> prism_info
now --> prism_cluster
This is fixed with my PR. It changes the internal section as it is needed.
