### PR TITLE
Adds not_built to jenkins build states map

### DIFF
--- a/cmk/plugins/jenkins/agent_based/jenkins_jobs.py
+++ b/cmk/plugins/jenkins/agent_based/jenkins_jobs.py
@@ -62,6 +62,7 @@ MAP_BUILD_STATES = {
     "failure": State.CRIT,  # fatal error
     "aborted": State.OK,  # manually aborted
     "null": State.WARN,  # module was not built
+    "not_built": State.OK,  # module was not built
     "none": State.OK,  # running
 }
 


### PR DESCRIPTION
## General information

Check_MK not handling Jenkins Jobs with build result not_build correct:

Exception:KeyError (not_built)

Traceback 
```
  File "/omd/sites/SITE/lib/python3/cmk/base/agent_based/checking/__init__.py", line 470, in get_aggregated_result
    result = _aggregate_results(
  File "/omd/sites/SITE/lib/python3/cmk/base/agent_based/checking/__init__.py", line 578, in _aggregate_results
    perfdata, results = _consume_and_dispatch_result_types(subresults)
  File "/omd/sites/SITE/lib/python3/cmk/base/agent_based/checking/__init__.py", line 622, in _consume_and_dispatch_result_types
    for subr in subresults:
  File "/omd/sites/SITE/lib/python3/cmk/base/api/agent_based/register/check_plugins.py", line 94, in filtered_generator
    for element in generator(*args, **kwargs):
  File "/omd/sites/SITE/lib/python3/cmk/base/plugins/agent_based/jenkins_jobs.py", line 163, in check_jenkins_jobs
    MAP_BUILD_STATES[job.build_result.lower()],
```
```
{'build_duration_key': 'jenkins_build_duration',
 'build_timestamp_key': 'jenkins_last_build',
 'infotext': 'State: Not built',
 'item': 'job-segment-6',
 'item_data': [(None,
                'job-segment-6',
                'notbuilt',
                100,
                1720524699.276,
                7261,
                'NOT_BUILT',
                130.836,
                1720530318)],
 'job': (None,
         'job-segment-6',
         'notbuilt',
         100,
         1720524699.276,
         7261,
         'NOT_BUILT',
         130.836,
         1720530318),
 'job_cleanup': 'notbuilt',
 'job_state': 'notbuilt',
 'now': 1720530577.4863226,
 'params': Parameters({'build_result': {'null': 0},
 'jenkins_last_build': (7200, 10800),
 'jenkins_time_since': (10800, 14400),
 'job_state': {'yellow': 0}}),
 'score_key': 'jenkins_job_score',
```

## Proposed changes

Added state not_build to MAP_BUILD_STATES as State OK.
