### PR TITLE
Fixed interactive mrpe run

### DIFF
--- a/agents/check_mk_agent.aix
+++ b/agents/check_mk_agent.aix
@@ -914,7 +914,7 @@ run_remote_plugins() {
         fi
 
         if [ -z "${interval}" ]; then
-            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}"
+            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}" < /dev/null
         else
             # Sourcing the agent here is not very performant, but we need 'run_mrpe', and not all shells support exporting of functions.
             _run_cached_internal "mrpe_${descr}" "${interval}" "${interval}" $((interval * 3)) $((interval * 2)) "MK_SOURCE_AGENT=yes . '${0}'; run_mrpe \"${descr}\" \"${cmdline}\""

--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -877,7 +877,7 @@ run_remote_plugins() {
         fi
 
         if [ -z "${interval}" ]; then
-            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}"
+            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}" < /dev/null
         else
             # Sourcing the agent here is not very performant, but we need 'run_mrpe', and not all shells support exporting of functions.
             _run_cached_internal "mrpe_${descr}" "${interval}" "${interval}" $((interval * 3)) $((interval * 2)) "MK_SOURCE_AGENT=yes . '${0}'; run_mrpe \"${descr}\" \"${cmdline}\""

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1976,7 +1976,7 @@ run_remote_plugins() {
         fi
 
         if [ -z "${interval}" ]; then
-            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}"
+            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}" < /dev/null
         else
             # Sourcing the agent here is not very performant, but we need 'run_mrpe', and not all shells support exporting of functions.
             _run_cached_internal "mrpe_${descr}" "${interval}" "${interval}" $((interval * 3)) $((interval * 2)) "MK_SOURCE_AGENT=yes . '${0}'; run_mrpe \"${descr}\" \"${cmdline}\""

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -1329,7 +1329,7 @@ run_remote_plugins() {
         fi
 
         if [ -z "${interval}" ]; then
-            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}"
+            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}" < /dev/null
         else
             # Sourcing the agent here is not very performant, but we need 'run_mrpe', and not all shells support exporting of functions.
             _run_cached_internal "mrpe_${descr}" "${interval}" "${interval}" $((interval * 3)) $((interval * 2)) "MK_SOURCE_AGENT=yes . '${0}'; run_mrpe \"${descr}\" \"${cmdline}\""

--- a/agents/check_mk_agent.solaris
+++ b/agents/check_mk_agent.solaris
@@ -963,7 +963,7 @@ run_remote_plugins() {
         fi
 
         if [ -z "${interval}" ]; then
-            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}"
+            ${MK_RUN_SYNC_PARTS} && run_mrpe "${descr}" "${cmdline}" < /dev/null
         else
             # Sourcing the agent here is not very performant, but we need 'run_mrpe', and not all shells support exporting of functions.
             _run_cached_internal "mrpe_${descr}" "${interval}" "${interval}" $((interval * 3)) $((interval * 2)) "MK_SOURCE_AGENT=yes . '${0}'; run_mrpe \"${descr}\" \"${cmdline}\""


### PR DESCRIPTION
## General information

If you run an interactive mrpe check the while loop running the mrpe execution stops right after the interactive command called as the interactive part "eats up" the stdin of the while loop.

## Bug reports

Create an mrpe file like:
```
# cat /etc/check_mk/mrpe.cfg
Hello_World_1                   docker run hello-world
Hello_World_2                   docker run -i hello-world
Hello_World_3                   docker run -i hello-world
```
and run check_mk_agent:
```
<<<mrpe>>>
(docker) Hello_World_1 0 Hello from Docker!This message shows that your installation appears to be working correctly.To generate this message, Docker took the following steps: 1. The Docker client contacted the Docker daemon. 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.    (amd64) 3. The Docker daemon created a new container from that image which runs the    executable that produces the output you are currently reading. 4. The Docker daemon streamed that output to the Docker client, which sent it    to your terminal.To try something more ambitious, you can run an Ubuntu container with: $ docker run -it ubuntu bashShare images, automate workflows, and more with a free Docker ID: https://hub.docker.com/For more examples and ideas, visit: https://docs.docker.com/get-started/
<<<mrpe>>>
(docker) Hello_World_2 0 Hello from Docker!This message shows that your installation appears to be working correctly.To generate this message, Docker took the following steps: 1. The Docker client contacted the Docker daemon. 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.    (amd64) 3. The Docker daemon created a new container from that image which runs the    executable that produces the output you are currently reading. 4. The Docker daemon streamed that output to the Docker client, which sent it    to your terminal.To try something more ambitious, you can run an Ubuntu container with: $ docker run -it ubuntu bashShare images, automate workflows, and more with a free Docker ID: https://hub.docker.com/For more examples and ideas, visit: https://docs.docker.com/get-started/
```

with the PR all 3 Hello_World gets executed as the stdin for each run is cutted of from the while loop and therefore the while loop can finish.

Testet on Debian Linux but should work also on all other distros.

And you are right calling docker without -i is the 100% percent correct solution but support guys like me doing stupid stuff ;)