### PR TITLE
Make HTTP code status 202 a valid notification response

### DIFF
--- a/cmk/notification_plugins/utils.py
+++ b/cmk/notification_plugins/utils.py
@@ -277,11 +277,11 @@ def post_request(
     return response
 
 
-def process_by_status_code(response: requests.Response, success_code: int = 200) -> int:
+def process_by_status_code(response: requests.Response, success_code: [200, 202]) -> int:
     status_code = response.status_code
     summary = f"{status_code}: {http_responses[status_code]}"
 
-    if status_code == success_code:
+    if status_code not in success_code:
         sys.stderr.write(summary)
         return 0
     if 500 <= status_code <= 599:

--- a/cmk/notification_plugins/utils.py
+++ b/cmk/notification_plugins/utils.py
@@ -281,7 +281,7 @@ def process_by_status_code(response: requests.Response, success_code: [200, 202]
     status_code = response.status_code
     summary = f"{status_code}: {http_responses[status_code]}"
 
-    if status_code not in success_code:
+    if status_code in success_code:
         sys.stderr.write(summary)
         return 0
     if 500 <= status_code <= 599:


### PR DESCRIPTION
There are notification scenarios, in which the receivers send back not a 200 HTTP code, but a 202 one.

In my opinion 202 should also be considered a valid successful notification. Taking the context into account (simple action of triggering a remote system and not depending in any way on what kind of issues , misconfiguration, etc exist on the target), I propose extending the list of generic valid responses, to include also this one.

In my specific case, I noticed the behavior when playing around with Microsoft's Workflows (since O365 connectors will be deprecated very shortly): CheckMK triggered the hook, the Workflow did its thing (successfully), but in CheckMK's perspective it was a failed action ("Failed to send notification. -- Response: -- 202: Accepted").

Again, as long as the request was accepted, the task to make sure it's properly processed (and also the mechanism to make this visible to the operator) should be a concern solely for the remote application.
