### PR TITLE
Fix for problem that files like bonding_masters are not skipped

### DIFF
--- a/agents/plugins/lnx_container_host_if.linux
+++ b/agents/plugins/lnx_container_host_if.linux
@@ -62,8 +62,10 @@ section_lnx_container_host_if() {
 
     for if_path in "${interface_filepath}"/*; do
 
-        # Directory does not exist or is empty
-        [ -e "${if_path}" ] || continue
+        # Check if Path is a directory, if not continue
+        [ -d "${if_path}" ] || continue
+        # Check if directory is empty, if true continue
+        [ -n "$(ls -A ${if_path})" ] || continue
 
         printf "name\v%s\t" "$(basename "${if_path}")"
         __read_network_interface_files "${if_path}" "${network_interface_metadata}"


### PR DESCRIPTION
## General information

This pull request fixes the problem that the script lnx_container_host_if.linux does not ignore possible files like bonding_masters as expected but generates empty values that are sent to the check_mk server which causes the plugin to crash:

**Error message:**
`ValueError (not enough values to unpack (expected 2, got 1))`

**Traceback:**
```
File "/omd/sites/nms_k8s/lib/python3/cmk/base/agent_based/data_provider.py", line 106, in _parse_raw_data
    return parse_function(list(raw_data))
  File "/omd/sites/nms_k8s/lib/python3/cmk/base/plugins/agent_based/section_lnx_container_host_if.py", line 138, in parse_lnx_container_host_if
    return [_create_interface(_parse_raw_stats(i)) for i in string_table], {}
  File "/omd/sites/nms_k8s/lib/python3/cmk/base/plugins/agent_based/section_lnx_container_host_if.py", line 138, in <listcomp>
    return [_create_interface(_parse_raw_stats(i)) for i in string_table], {}
  File "/omd/sites/nms_k8s/lib/python3/cmk/base/plugins/agent_based/section_lnx_container_host_if.py", line 47, in _parse_raw_stats
    k, v = stats.split("\v")
```

## Bug reports
Read following Post:
[Network monitoring using Kubernetes Agent fails due to network bonding](https://forum.checkmk.com/t/network-monitoring-using-kubernetes-agent-fails-due-to-network-bonding/48419)

## Proposed changes

Now the bash script checks first whether the path is a folder or a file and then checks whether the folder is empty or not.