### PR TITLE
Make the agent work with Home Assistant OS

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -337,8 +337,9 @@ hex_decode() {
     # We might not have xxd available, so we have to do it manually.
     # Be aware that this implementation is very slow and should not be used for large data.
     local hex="$1"
-    for ((i = 0; i < ${#hex}; i += 2)); do
+    while [ "$i" -lt ${#hex} ]; do
         printf '%b' "\x${hex:i:2}"
+        $i = $i+2
     done
 }
 
@@ -405,9 +406,7 @@ define_optionally_encrypt() {
                 # kdf: pbkdf2, 600.000 iterations
 
                 local salt_hex key_hex iv_hex
-                read -r salt_hex key_hex iv_hex <<<"$(
-                    parse_kdf_output "$(openssl enc -aes-256-cbc -md sha256 -pbkdf2 -iter 600000 -k "${1}" -P)"
-                )"
+                read -r salt_hex key_hex iv_hex "$(parse_kdf_output "$(openssl enc -aes-256-cbc -md sha256 -pbkdf2 -iter 600000 -k "${1}" -P)")"
 
                 printf "05"
                 printf "%s" "${2}"
@@ -420,9 +419,7 @@ define_optionally_encrypt() {
                 # kdf: openssl custom kdf based on sha256
 
                 local salt_hex key_hex iv_hex
-                read -r salt_hex key_hex iv_hex <<<"$(
-                    parse_kdf_output "$(openssl enc -aes-256-cbc -md sha256 -k "${1}" -P)"
-                )"
+                read -r salt_hex key_hex iv_hex "$(parse_kdf_output "$(openssl enc -aes-256-cbc -md sha256 -k "${1}" -P)")"
 
                 printf "04"
                 printf "%s" "${2}"
@@ -493,14 +490,17 @@ HERE
     #
 
     echo "OSType: linux"
-    while read -r line; do
-        raw_line="${line//\"/}"
-        case $line in
-            ID=*) echo "OSPlatform: ${raw_line##*=}" ;;
-            NAME=*) echo "OSName: ${raw_line##*=}" ;;
-            VERSION_ID=*) echo "OSVersion: ${raw_line##*=}" ;;
-        esac
-    done <<<"$(cat /etc/os-release 2>/dev/null)"
+    OS_Release=/etc/os-release
+    if [ -e "$OS_Release" ]; then
+        while read -r line; do
+            raw_line="${line//\"/}"
+            case $line in
+                ID=*) echo "OSPlatform: ${raw_line##*=}" ;;
+                NAME=*) echo "OSName: ${raw_line##*=}" ;;
+                VERSION_ID=*) echo "OSVersion: ${raw_line##*=}" ;;
+            esac
+        done < $OS_Release
+    fi
 
     #
     # BEGIN COMMON AGENT CODE


### PR DESCRIPTION
## General information

The current Linux agent doesn't work with Home Assistant OS (HAOS: https://www.home-assistant.io/installation/linux) because `/bin/bash` is in fact a redirection to `/bin/sh`. The `openwrt` agent is compatible with HAOS but doesn't provide as much information. It is notably missing the systemd agent information.

## Proposed changes

To make the Linux agent work with `sh`, the `<<<` operators need to be replaced and the bash `for` loop syntax needs to be adapted as it is not compatible.

I am not sure what is the best approach to this as I don't have a variety of systems to test it on; it might break the agent on other systems although I didn't encounter any issue in my lab with my other Linux distros. A separate agent might be ideal but I admit we're entering a very niche OS that would not be worth supporting a completely total different agent. In that regard, it would probably be better for me to submit a new agent specifically for HAOS to the Checkmk Exchange, but I still wanted to leave a trace on the git and have your thoughts on the matter.

I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.