### PR TITLE
aruba_wlc_clients: use utf8 instead of ascii decoding

### DIFF
--- a/cmk/plugins/collection/agent_based/aruba_wlc_clients.py
+++ b/cmk/plugins/collection/agent_based/aruba_wlc_clients.py
@@ -14,7 +14,7 @@ from cmk.plugins.lib.wlc_clients import ClientsTotal, WlcClientsSection
 def parse_aruba_wlc_clients(string_table: Sequence[StringTable]) -> WlcClientsSection[ClientsTotal]:
     section: WlcClientsSection[ClientsTotal] = WlcClientsSection()
     for oid_fragment, num_clients_str in string_table[0]:
-        ssid_name = bytes(int(x) for x in oid_fragment.split(".")[1:]).decode("ascii")
+        ssid_name = bytes(int(x) for x in oid_fragment.split(".")[1:]).decode("utf8")
         if ssid_name == "":
             continue
         num_clients = int(num_clients_str)


### PR DESCRIPTION
## General information
Affected devices: WLAN controllers from Aruba
The `aruba_wlc_clients` check shows how many clients are connected for each SSID.

As far as I know, IEEE 802.11 (correct me if I'm wrong, but I think this was introduced with IEEE 802.11-2007 or IEEE 802.11-2012) specifies that an SSID may contain any UTF-8 character. Limiting it to the ASCII character set would therefore be insufficient and lead to errors.

## Bug reports
Information about the system or setup should be unimportant, as the error can be reproduced completely independently of the setup and we are talking about a standard here.

Example with ASCII encoding:
```python
>>> bytes(int(x) for x in "11.195.164".split(".")[1:]).decode("ascii")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

## Proposed changes
UTF-8 is used instead of ASCII encoding.
I don't think this would break any running system.

```python
>>> bytes(int(x) for x in "11.195.164".split(".")[1:]).decode("utf8")
'ä'
```