### PR TITLE
FRITZ!Box: use 64-bit traffic counters if available

### DIFF
--- a/cmk/plugins/fritzbox/agent_based/fritz.py
+++ b/cmk/plugins/fritzbox/agent_based/fritz.py
@@ -65,8 +65,8 @@ def _section_to_interface(section: Section) -> interfaces.Section[interfaces.Int
                 ),
             ),
             interfaces.Counters(
-                in_octets=int(section.get("NewTotalBytesReceived", 0)),
-                out_octets=int(section.get("NewTotalBytesSent", 0)),
+                in_octets=int(section.get("NewX_AVM_DE_TotalBytesReceived64", section.get("NewTotalBytesReceived", 0))),
+                out_octets=int(section.get("NewX_AVM_DE_TotalBytesSent64", section.get("NewTotalBytesSent", 0))),
             ),
         )
     ]


### PR DESCRIPTION
The current FRITZ!Box check uses traffic counters that are 32-bit wide. This means that they overflow quickly, causing gaps in graphs & wrong traffic stats in general. Most current FRITZ!Box models also send additional 64-bit counters. These can & should be used if they're present, which is what this fix implements. If they're not available, the old 32-bit counters are used.