### PR TITLE
Changed pathes to FreeBSD layout

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -118,8 +118,8 @@ set_up_current_shell() {
 
 set_variable_defaults() {
     : "${MK_LIBDIR:=/usr/local/lib/check_mk_agent}"
-    : "${MK_CONFDIR:=/etc/check_mk}"
-    : "${MK_VARDIR:=/var/lib/check_mk_agent}"
+    : "${MK_CONFDIR:=/usr/local/etc/check_mk}"
+    : "${MK_VARDIR:=/var/db/check_mk_agent}"
     : "${MK_LOGDIR:=/var/log/check_mk_agent}"
 
     # some 'booleans'
@@ -137,7 +137,7 @@ preamble_1() {
 
     # Make sure locally installed binaries are found
     # Only add binaries if they are not already in the path! If you append to path in a loop the process will
-    # eventually each the 128k size limit for the environment and become a zombie process. See execve manpage.
+    # eventually reach the 128k size limit for the environment and become a zombie process. See execve manpage.
     [ "${PATH#*"/usr/local/bin"}" != "${PATH}" ] || PATH="${PATH}:/usr/local/bin"
     [ "${PATH#*"/usr/local/sbin"}" != "${PATH}" ] || PATH="${PATH}:/usr/local/sbin"
     [ -d "/var/qmail/bin" ] && { [ "${PATH#*"/var/qmail/bin"}" != "${PATH}" ] || PATH="${PATH}:/var/qmail/bin"; }


### PR DESCRIPTION
## General information

This aligns check_mk_agent with the filesystem hierarchy found on FreeBSD.

## Proposed changes

On FreeBSD, check_mk_agent is not part of the base system, but installed via ports or (pre-compiled) packages. Configuration files for these 3rd party applications are expected in /usr/local/etc.
Also, FreeBSD has no /var/lib, but /var/db.