### PR TITLE
Avoid loading zfs.ko

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -394,7 +394,7 @@ run_purely_synchronous_sections() {
     fi
 
     # Filesystem usage for ZFS
-    if inpath zfs; then
+    if kldstat -m zfs -q && inpath zfs; then
         echo '<<<zfsget>>>'
         zfs get -t filesystem,volume -Hp name,quota,used,avail,mountpoint,type ||
             zfs get -Hp name,quota,used,avail,mountpoint,type
@@ -570,7 +570,7 @@ run_purely_synchronous_sections() {
     fi
 
     # check zpool status
-    if inpath zpool; then
+    if kldstat -m zfs -q && inpath zpool; then
         echo "<<<zpool_status>>>"
         zpool status -x | grep -v "errors: No known data errors"
     fi


### PR DESCRIPTION
## General information

This avoids loading of the ZFS kernel module.

## Bug reports

Calling zpool or zfs automatically loads zfs.ko. This might not be desired on systems without any ZFS filesystems.

## Proposed changes

Call zfs and zpool only if zfs.ko has already been loaded.