### PR TITLE
Added support for DragonFly BSD Mail Agent (dma)

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -561,6 +561,14 @@ run_purely_synchronous_sections() {
     elif [ -x /usr/sbin/ssmtp ]; then
         echo '<<<postfix_mailq>>>'
         mailq 2>&1 | sed 's/^[^:]*: \(.*\)/\1/' | tail -n 6
+    elif [ -x /usr/libexec/dma ]; then
+        # Check status of DragonFly BSD Mail Agent (dma)
+        echo '<<<postfix_mailq>>>'
+        /usr/libexec/dma -bp | tail -n 7
+        dma_count=$(/usr/libexec/dma -bp | grep "^ID" | wc -l)
+        if [ "${dma_count}" -gt 0 ]; then
+            echo "${dma_count} Requests."
+        fi
     fi
 
     # Check status of qmail mailqueue

--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -564,11 +564,8 @@ run_purely_synchronous_sections() {
     elif [ -x /usr/libexec/dma ]; then
         # Check status of DragonFly BSD Mail Agent (dma)
         echo '<<<postfix_mailq>>>'
-        /usr/libexec/dma -bp | tail -n 7
-        dma_count=$(/usr/libexec/dma -bp | grep "^ID" | wc -l)
-        if [ "${dma_count}" -gt 0 ]; then
-            echo "${dma_count} Requests."
-        fi
+        echo -n QUEUE_deferred
+        /usr/libexec/dma -bp | grep ^ID | wc -l
     fi
 
     # Check status of qmail mailqueue


### PR DESCRIPTION
## General information

Add support for mailq output if DragonFly BSD Mail Agent (dma) is installed on FreeBSD.
Starting FreeBSD 14, dma became the default MTA.

## Proposed changes

Output no more than 7 lines (=2 queued mails) of dma's mailq output.
As dma outputs no summarizing status line, construct one if there is at least one queued mail.