### PR TITLE
Avoid one call of grep

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -466,7 +466,7 @@ run_purely_synchronous_sections() {
 
     # Multipathing is supported in FreeBSD by now
     # http://www.mywushublog.com/2010/06/freebsd-and-multipath/
-    if kldstat -v | grep g_multipath >/dev/null; then
+    if kldstat -m g_multipath -q; then
         echo '<<<freebsd_multipath>>>'
         gmultipath status | grep -v ^Name
     fi


### PR DESCRIPTION
## General information

On FreeBSD, when called with parameter "-m", kldstat indicates via its exit code whether that symbol has been loaded into the kernel. In addition, "-q" suppresses any output.

## Proposed changes

Use the exit code of kldstat to check whether geom_multipath.ko has been loaded, thus saving a call of grep.