### PR TITLE
Implement 24-hour check for apt cache updates to reduce network-load …

### DIFF
--- a/agents/plugins/mk_apt
+++ b/agents/plugins/mk_apt
@@ -23,12 +23,14 @@ DO_UPDATE=yes
 
 check_apt_update() {
     if [ "$DO_UPDATE" = yes ]; then
-        # NOTE: Even with -qq, apt-get update can output several lines to
-        # stderr, e.g.:
-        #
-        # W: There is no public key available for the following key IDs:
-        # 1397BC53640DB551
-        apt-get update -qq 2>/dev/null
+        if [ $(($(date +%s) - $(date -r "$FILE" +%s))) -gt 86400 ]; then
+            # NOTE: Even with -qq, apt-get update can output several lines to
+            # stderr, e.g.:
+            #
+            # W: There is no public key available for the following key IDs:
+            # 1397BC53640DB551
+            apt-get update -qq 2>/dev/null
+        fi
     fi
     apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Show-User-Simulation-Note=false' -s -qq "$UPGRADE" | grep -v '^Conf'
 }

--- a/agents/plugins/mk_apt
+++ b/agents/plugins/mk_apt
@@ -20,10 +20,11 @@ CMK_VERSION="2.4.0b1"
 # This variable can either be "upgrade" or "dist-upgrade"
 UPGRADE=upgrade
 DO_UPDATE=yes
+FILE="/var/cache/apt/pkgcache.bin"
 
 check_apt_update() {
     if [ "$DO_UPDATE" = yes ]; then
-        if [ $(($(date +%s) - $(date -r "$FILE" +%s))) -gt 86400 ]; then
+        if [ $(($(date +%s) - $(date -r "/var/cache/apt/pkgcache.bin" +%s))) -gt 86400 ]; then
             # NOTE: Even with -qq, apt-get update can output several lines to
             # stderr, e.g.:
             #


### PR DESCRIPTION
…and improve running times

## Proposed changes
## General information
This commit introduces a time-based check to ensure the apt-get cache is updated only once every 24 hours, optimizing resource usage and reducing network load.

Why:
Many Linux servers, including those within our company, utilize unattended upgrades that automatically update the package database. Limiting cache updates to once every 24 hours helps to minimize unnecessary load on our custom repo mirror/apt-cacher, especially when other services may have already performed an update.

Technical Details:
Modification Time Check: The script checks the modification timestamp of /var/cache/apt/pkgcache.bin to determine when the last update occurred. It calculates the time elapsed since that update using the timestamp.

Time Difference Calculation: If more than 24 hours (86400 seconds) have passed since the last update, the script triggers an apt-get update, ensuring updates are performed only when necessary.

Benefits:
Server Load Reduction: By throttling updates, we reduce the load on package servers, apt-cacher proxies, or custom mirrors, preventing server strain and ensuring better availability of resources.

Resource Efficiency: This approach conserves bandwidth and processing power by avoiding unnecessary updates, particularly in stable environments where frequent updates provide minimal benefit.

Reduced Script Run Time: By skipping unnecessary updates, the script executes more quickly.