### PR TITLE
timemachine: removesuffix .backup

### DIFF
--- a/cmk/plugins/collection/agent_based/timemachine.py
+++ b/cmk/plugins/collection/agent_based/timemachine.py
@@ -55,7 +55,7 @@ def _check(now: datetime.datetime, params: Mapping[str, Any], section: str) -> C
         )
         return
 
-    raw_backup_time = section.split("/")[-1]
+    raw_backup_time = section.split("/")[-1].removesuffix('.backup')
     backup_time = datetime.datetime.strptime(raw_backup_time, "%Y-%m-%d-%H%M%S")
     backup_age = (now - backup_time).total_seconds()
 


### PR DESCRIPTION
timemachine: remove .backup suffix from `tmutil latestbackup` output

## General information

The output of `tmutil latestbackup` on my macOS looks like this:
`/Volumes/.timemachine/CA30DC01-325C-43C2-8187-E404168D2F8B/2024-08-17-001115.backup/2024-08-17-001115.backup`

Because of the `.backup` suffix the check fails with a python error converting the timestamp extracted from the filename.

## Bug reports

+ macOS 14.6.1

## Proposed changes

remove `.backup` suffix if exists
