### PR TITLE
Update job.py

### DIFF
--- a/cmk/plugins/collection/agent_based/job.py
+++ b/cmk/plugins/collection/agent_based/job.py
@@ -176,8 +176,7 @@ agent_section_job = AgentSection(
 
 def discover_job(section: Section) -> DiscoveryResult:
     for jobname, job in section.items():
-        if not job["running"]:
-            yield Service(item=jobname)
+        yield Service(item=jobname)
 
 
 _METRIC_SPECS: Mapping[str, tuple[str, Callable]] = {


### PR DESCRIPTION
Fixing issue: running jobs were not enumerated thus omitted from discovery.

The issue is related to monitoring time-based processes (Cronjobs) https://docs.checkmk.com/latest/en/monitoring_jobs.html.

What is the expected behaviour: all jobs monitored on the Linux host are discovered all the time.

What is the current behaviour: when a job is running at the time of the discovery, that job will not be discovered.