### PR TITLE
reflip diskstat

### DIFF
--- a/cmk/plugins/collection/graphing/disk_throughput.py
+++ b/cmk/plugins/collection/graphing/disk_throughput.py
@@ -11,14 +11,14 @@ metric_disk_read_throughput = metrics.Metric(
     name="disk_read_throughput",
     title=Title("Read throughput"),
     unit=UNIT_BYTES_PER_SECOND,
-    color=metrics.Color.BLUE,
+    color=metrics.Color.GREEN,
 )
 
 metric_disk_write_throughput = metrics.Metric(
     name="disk_write_throughput",
     title=Title("Write throughput"),
     unit=UNIT_BYTES_PER_SECOND,
-    color=metrics.Color.GREEN,
+    color=metrics.Color.BLUE,
 )
 
 perfometer_disk_throughput = perfometers.Bidirectional(
@@ -39,21 +39,21 @@ graph_disk_throughput = graphs.Bidirectional(
     name="disk_throughput",
     title=Title("Disk throughput"),
     lower=graphs.Graph(
-        name="disk_read_throughput",
-        title=Title("Read throughput"),
-        compound_lines=["disk_read_throughput"],
-        simple_lines=[
-            metrics.WarningOf("disk_read_throughput"),
-            metrics.CriticalOf("disk_read_throughput"),
-        ],
-    ),
-    upper=graphs.Graph(
         name="disk_write_throughput",
         title=Title("Write throughput"),
         compound_lines=["disk_write_throughput"],
         simple_lines=[
             metrics.WarningOf("disk_write_throughput"),
             metrics.CriticalOf("disk_write_throughput"),
+        ],
+    ),
+    upper=graphs.Graph(
+        name="disk_read_throughput",
+        title=Title("Read throughput"),
+        compound_lines=["disk_read_throughput"],
+        simple_lines=[
+            metrics.WarningOf("disk_read_throughput"),
+            metrics.CriticalOf("disk_read_throughput"),
         ],
     ),
 )


### PR DESCRIPTION
## General information

With the latest update I noticed that the graphs for diskstat the read/write throughput had their colors flipped and their orientation in the graph too. This to me are not two errors that together cancel out, but are easy to miss and if I look closer I it is confusing. 

@si-23 The flip originates on Change-Id: Idecd857ee722ef98f8a21e1a9c6101690e58a316
And given the commit title doesn't seem intentional.