### PR TITLE
SUP-19768: Add Cisco UCS fault check

### DIFF
--- a/cmk/plugins/cisco_ucs/__init__.py
+++ b/cmk/plugins/cisco_ucs/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+#   _____  __          __  _____
+#  / ____| \ \        / / |  __ \
+# | (___    \ \  /\  / /  | |__) |
+#  \___ \    \ \/  \/ /   |  _  /
+#  ____) |    \  /\  /    | | \ \
+# |_____/      \/  \/     |_|  \_\
+#
+# (c) 2024 SWR
+# @author Frank Baier <frank.baier@swr.de>
+#

--- a/cmk/plugins/cisco_ucs/agent_based/cisco_ucs_faults.py
+++ b/cmk/plugins/cisco_ucs/agent_based/cisco_ucs_faults.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+#   _____  __          __  _____
+#  / ____| \ \        / / |  __ \
+# | (___    \ \  /\  / /  | |__) |
+#  \___ \    \ \/  \/ /   |  _  /
+#  ____) |    \  /\  /    | | \ \
+# |_____/      \/  \/     |_|  \_\
+#
+# (c) 2024 SWR
+# @author Frank Baier <frank.baier@swr.de>
+#
+#
+from cmk.agent_based.v2 import (
+    CheckPlugin,
+    Service,
+    Result,
+    State,
+)
+from collections.abc import Mapping, Sequence
+from cmk.plugins.lib.cisco_ucs import check_cisco_fault, Fault
+from cmk.agent_based.v1.type_defs import CheckResult, DiscoveryResult
+
+
+def discover_cisco_ucs_faults(section: Mapping[str, Sequence[Fault]] | None,) -> DiscoveryResult:
+    yield Service()
+
+
+def check_cisco_ucs_faults(section: Mapping[str, Sequence[Fault]] | None,) -> CheckResult:
+    if not section:
+        yield Result(state=State.OK, notice="No faults")
+        return
+
+    for id, fault in section.items():
+        yield from check_cisco_fault(fault)
+
+
+check_plugin_cisco_ucs_faults = CheckPlugin(
+    name="cisco_ucs_faults",
+    sections=["cisco_ucs_fault"],
+    service_name="Cisco UCS Faults",
+    discovery_function=discover_cisco_ucs_faults,
+    check_function=check_cisco_ucs_faults,
+)


### PR DESCRIPTION
## General information

Add:
 + Cisco UCS Fault Table Check because Errors are not shown in other Checks for example Memory (Ack Flag already set in SNMP) and Fan (no information about Fan problems in fan SNMP OIDs)

More information in SUP-19768 and discussed with your Product Management
