### PR TITLE
fix check_mk_agent.openbsd multi network interfaces support

### DIFF
--- a/agents/check_mk_agent.openbsd
+++ b/agents/check_mk_agent.openbsd
@@ -181,7 +181,7 @@ section_misc_sections() {
 
     # adjust internal field separator to get lines from netstat and backup it before
     OFS=$IFS
-    IFS=''
+    IFS=$(echo -n "\n\b")
 
     # collect netstat values and interface number
     for NS in $NETSTAT_OUTPUT; do


### PR DESCRIPTION
current behaviour: the script work well if there is only one network interface configured but as soon as more then one network interface exists the reports just garbage.

the cause: seeting IFS to '' will skip any substitution resulting in for loop only executing once (the list to iterate over just consists of a single value)

solution: set IFS to only contain a newline

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
