### PR TITLE
SUP-20798: fixes shebang, HOMEDIR grep, su  shell, if -ne typo

### DIFF
--- a/agents/plugins/mk_db2.aix
+++ b/agents/plugins/mk_db2.aix
@@ -1,4 +1,4 @@
-#!/usr/bin/ksh
+#!/usr/bin/ksh93
 # Copyright (C) 2019 Checkmk GmbH - License: GNU General Public License v2
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
@@ -65,11 +65,11 @@ function waitmax {
 function query_instance {
     INSTANCE=$1
     # find home directory
-    HOMEDIR=$(grep "^$INSTANCE" /etc/passwd | awk -F: '{print $6}' | grep "$INSTANCE$")
+    HOMEDIR=$(grep -w "^$INSTANCE:" /etc/passwd | awk -F: '{print $6}')
     NOW=$(perl -e "print time();")
 
     waitmax 200 <<WAITMAX
-    su $INSTANCE << EOF
+    su - $INSTANCE -c "/usr/bin/ksh93" << EOF
 
     if [ ! -f $HOMEDIR/sqllib/db2profile ] ;
     then
@@ -99,7 +99,7 @@ function query_instance {
     DB_PORT='port 0'
     for DB in \\\$DBS; do
             db2 connect to \\\$DB > /dev/null;
-            if [ $? -nq 0 ] ; then
+            if [ $? -ne 0 ] ; then
                 exit 1
             fi
 


### PR DESCRIPTION
## General information

I am Checkmk employee.

The mk_db2.aix agent plugin did not work on a recent AIX 7.2

During a session with a customer we were able to make it work again.

We found and fixed around 3 problems.
One of them is a typo in a  **if** statement that was in the code since 2015. 

## Bug reports

* OS AIX 7.2 on power architecture
* See SUP-20798 for details

## Proposed changes

Please just have a look into a side by side diff.


* Line 1 ksh93 seems to be more current than ksh
* Line 68 tried to extract the user home directory. The grep at the end does not make sense, it assumes that the homedir also contains the instancename/username which is not always the case. I made the first grep more specific with -w and also  adding the colon :  to not to match users that contain the value of $INSTANCE as substring.

* Line 72,  we added to - because this gives a completer environment, a login environ.
  I this case the $INSTANCE users SHELL is csh. csh is very limited and can not interpret the code in the EOT block. 
  Therefore we  let the EOT heredocument block run also in ksh93.
  
  * Line 102 was obviously a typo  
