### PR TITLE
Fix Huawei WLC AP Parsing crash on offline APs

### DIFF
--- a/cmk/base/legacy_checks/huawei_wlc_aps.py
+++ b/cmk/base/legacy_checks/huawei_wlc_aps.py
@@ -46,6 +46,10 @@ ap_state_map = {
 def parse_huawei_wlc_aps(string_table):
     parsed = {}
 
+    # Filter Access Point Information from Offline Access Points
+    down_states = [key for key, value in ap_state_map.items() if value.value == 2]
+    string_table[0] = [line for line in string_table[0] if line[0] not in down_states]
+
     aps_info1, aps_info2 = string_table
 
     # Access-Points
@@ -56,10 +60,6 @@ def parse_huawei_wlc_aps(string_table):
         # aps_info1             aps_info2
         # [line]        -->     [2,4GHZ Info]
         #               -->     [5GHz Info]
-
-        # Skip Access Points Reported by the Controller which have no Channel Information
-        if 2 * idx + 1 >= len(aps_info2):
-            continue
         
         status, mem, cpu, temp, con_users = ap_info1
         ap_id, radio_state_2GHz, ch_usage_2GHz, users_online_2GHz = aps_info2[2 * idx]

--- a/cmk/base/legacy_checks/huawei_wlc_aps.py
+++ b/cmk/base/legacy_checks/huawei_wlc_aps.py
@@ -56,6 +56,11 @@ def parse_huawei_wlc_aps(string_table):
         # aps_info1             aps_info2
         # [line]        -->     [2,4GHZ Info]
         #               -->     [5GHz Info]
+
+        # Skip Access Points Reported by the Controller which have no Channel Information
+        if 2 * idx + 1 >= len(aps_info2):
+            continue
+        
         status, mem, cpu, temp, con_users = ap_info1
         ap_id, radio_state_2GHz, ch_usage_2GHz, users_online_2GHz = aps_info2[2 * idx]
         _ap_id, radio_state_5GHz, ch_usage_5GHz, users_online_5GHz = aps_info2[2 * idx + 1]


### PR DESCRIPTION
## General information

**Affected Device:** Huawei AC6508 Wireless LAN Controller (WLC)
**Software Version:** Huawei NMS Version 2.23.00.100.932
**CheckMK Version:** MSP 2.3.0p12
**Issue Summary:** The Huawei AC6508 WLC crashes when an offline Access Point (AP) is reported by the controller. The crash occurs due to an out-of-range access attempt on the aps_info2 list when the AP is no longer available, resulting in a system failure.

## Bug reports

**Operating System:**
Debian 12 running Checkmk MSP 2.3.0p12

**Steps to Reproduce:**
- Run a device discovery on a Huawei AC6508 WLC Controller with disconnected (offline) Access Points.
- Run the attached string_table against the function parse_huawei_wlc_aps
[test.txt](https://github.com/user-attachments/files/17340804/test.txt)

**SNMPWalk**
Following File contains a Full SNMPWalk which is redacted.
[Huawei AC6508 WLC snmpwalk.txt](https://github.com/user-attachments/files/17340827/Huawei.AC6508.WLC.snmpwalk.txt)

**Crash Report ID:**
ID: 48274138-87a8-11ef-a33a-0050568fc548

## Proposed changes

**Expected Behavior:**
When an AP goes offline, CheckMK should handle it gracefully, avoiding any out-of-range memory access. The system should log appropriate warnings or errors rather than attempting to access data from the unavailable AP.

Proposed Patch Change:
The patch modifies the AP handling logic to skip further parsing of AP information when the AP is not available. This prevents out-of-range access and stabilizes the system.
