### PR TITLE
agent_kube: Add request_client.merge_environment_settings to api_server.py

### DIFF
--- a/cmk/special_agents/utils_kubernetes/api_server.py
+++ b/cmk/special_agents/utils_kubernetes/api_server.py
@@ -150,8 +150,14 @@ def send_request(
     prepared_request = request_client.prepare_request(request)
     return request_client.send(
         prepared_request,
-        verify=client_config.verify_cert_api,
         timeout=client_config.requests_timeout(),
+        **request_client.merge_environment_settings(
+            url=request.url,
+            proxies={},
+            stream=None,
+            verify=client_config.verify_cert_api,
+            cert=None,
+        ),
     )
 
 


### PR DESCRIPTION
## General information

After upgrading from version 2.2.0p32cee to 2.3.0p19cee I had a similar problem as described in the following work:
https://checkmk.com/werk/16892
Here only the problem with connecting to the agent was fixed, but not the one for connecting to the Kubernetes API.

## Bug reports
**CMK version:** 2.3.0p19
**OS version:** Ubuntu Server 20.04
**Kubernetes:** RKE2(v1.30.5+rke2r1)

**Error message:**  cmk.special_agents.agent_kube.ClusterConnectionError: Failed to establish a connection at URL https://<url>/version

**Output of “~/share/check_mk/agents/special/agent_kube --debug ”:** 


```
Traceback (most recent call last):
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connectionpool.py", line 466, in _make_request
    self._validate_conn(conn)
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connectionpool.py", line 1095, in _validate_conn
    conn.connect()
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connection.py", line 730, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connection.py", line 909, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
               ^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/util/ssl_.py", line 469, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/util/ssl_.py", line 513, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/lib/python3.12/ssl.py", line 455, in wrap_socket
    return self.sslsocket_class._create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/lib/python3.12/ssl.py", line 1042, in _create
    self.do_handshake()
  File "/omd/sites/nms_k8s/lib/python3.12/ssl.py", line 1320, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connectionpool.py", line 789, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connectionpool.py", line 490, in _make_request
    raise new_e
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/omd/sites/nms_k8s/local/lib/python3/requests/adapters.py", line 667, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/connectionpool.py", line 843, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/urllib3/util/retry.py", line 519, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='x.x.x.x', port=6443): Max retries exceeded with url: /version (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/omd/sites/nms_k8s/lib/python3/cmk/special_agents/agent_kube.py", line 851, in main
    api_data = from_kubernetes(
               ^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/lib/python3/cmk/special_agents/utils_kubernetes/api_server.py", line 586, in from_kubernetes
    raw_version = core_api.query_raw_version()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/lib/python3/cmk/special_agents/utils_kubernetes/api_server.py", line 165, in query_raw_version
    return send_request(self._config, self._client, request).text
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/lib/python3/cmk/special_agents/utils_kubernetes/api_server.py", line 151, in send_request
    return request_client.send(
           ^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/omd/sites/nms_k8s/local/lib/python3/requests/adapters.py", line 698, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='x.x.x.x', port=6443): Max retries exceeded with url: /version (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/omd/sites/nms_k8s/share/check_mk/agents/special/agent_kube", line 11, in <module>
    sys.exit(main())
             ^^^^^^
  File "/omd/sites/nms_k8s/lib/python3/cmk/special_agents/agent_kube.py", line 863, in main
    raise ClusterConnectionError(
cmk.special_agents.agent_kube.ClusterConnectionError: Failed to establish a connection at URL https://x.x.x.x:6443/version
```

## Proposed changes

In this fix for the Kubernetes API, the same solution is used as for the connection establishment with the agent in a customized version. 
