### PR TITLE
Setting MSteams card summary to alert title

### DIFF
--- a/cmk/notification_plugins/msteams.py
+++ b/cmk/notification_plugins/msteams.py
@@ -53,6 +53,7 @@ def _msteams_msg(
 
     return {
         "type": "message",
+        "summary": substitute_context(title, context),
         "attachments": [
             {
                 "contentType": "application/vnd.microsoft.card.adaptive",


### PR DESCRIPTION
Very small adjustment to the msteams alert plugin. Add "summary" line to replace 'Sent a Card' In Teams message preview with title of the alert.