### PR TITLE
fix: allow special server_version such as TDE

### DIFF
--- a/agents/plugins/mk_postgres.py
+++ b/agents/plugins/mk_postgres.py
@@ -226,7 +226,7 @@ class PostgresBase:
         out = self.run_sql_as_db_user("SHOW server_version;")
         if out == "":
             raise PostgresPsqlError("psql connection returned with no data")
-        version_as_string = out.split()[0]
+        version_as_string = out.split("_")[0]
         # Use Major and Minor version for float casting: "12.6.4" -> 12.6
         return float(".".join(version_as_string.split(".")[0:2]))
 


### PR DESCRIPTION
# show server_version;
 server_version
----------------
 15.8_TDE_1.1.8
(1 row)

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

We are running Cybertec Postgresql version and the server_string doesn't match for our monitoring.

## Bug reports

Please include:

+ RedHat 8.10
+ psql (15.8_TDE_1.1.8)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?