### PR TITLE
Fix: mk-job (linux) support versions without perl again

### DIFF
--- a/agents/mk-job
+++ b/agents/mk-job
@@ -52,7 +52,15 @@ cleanup() {
     rm "${RUNNING_FILE}" 2>/dev/null
 }
 
-echo "start_time $(perl -e 'print time')" >"${TMP_FILE}" 2>/dev/null
+try_perl() {
+    echo "start_time $(perl -e 'print time')" >"${TMP_FILE}" 2>/dev/null
+}
+
+fallback_date() {
+    date +"start_time %s" >"${TMP_FILE}" 2>/dev/null
+}
+try_perl || fallback_date
+
 cp "${TMP_FILE}" "${RUNNING_FILE}" 2>/dev/null
 
 if [ ! -w "${RUNNING_FILE}" ]; then


### PR DESCRIPTION
Current Linux Distributions like RHEL 8 + 9 do not install Perl as default.
So with the Update Checkmk 2.3, mk-job fails there since an earlier workaround for aix/ solaris to get a timestamp using perl, was made a default now for as well Linux.

This fix tries to restore the function on GNU Linux again if perl is missing, but without reverting the use of perl as default.
Since GNU date should always have the %s parameter, just BSD or BusyBox can lack the support, that's maybe a reasonable approach. 