### PR TITLE
Add no-agents option to omd backup

### DIFF
--- a/omd/packages/omd/omdlib/backup.py
+++ b/omd/packages/omd/omdlib/backup.py
@@ -94,6 +94,9 @@ def get_exclude_patterns(options: CommandOptions) -> list[str]:
         excludes.append("var/pnp4nagios/states/*")
         excludes.append("var/check_mk/rrd/*")
 
+    if "no-agents" in options or "no-past" in options:
+        excludes.append("var/check_mk/agents/*")
+
     if "no-logs" in options or "no-past" in options:
         # Logs of different components
         excludes.append("var/log/*.log")

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3867,7 +3867,7 @@ exclude_options = [
         "no-past",
         "N",
         False,
-        "do not copy RRD files, agent files the monitoring history and log files",
+        "do not copy RRD files, agent files, the monitoring history and log files",
     ),
 ]
 

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3862,7 +3862,7 @@ class Option(NamedTuple):
 exclude_options = [
     Option("no-rrds", None, False, "do not copy RRD files (performance data)"),
     Option("no-logs", None, False, "do not copy the monitoring history and log files"),
-    Option("no-agents", None, False, "do not copy agent files created by the agent bakery"),
+    Option("no-agents", None, False, "do not copy agent files created by the bakery"),
     Option(
         "no-past",
         "N",

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3867,7 +3867,7 @@ exclude_options = [
         "no-past",
         "N",
         False,
-        "do not copy RRD files, agent files the monitoring history and log files"
+        "do not copy RRD files, agent files the monitoring history and log files",
     ),
 ]
 

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3862,7 +3862,8 @@ class Option(NamedTuple):
 exclude_options = [
     Option("no-rrds", None, False, "do not copy RRD files (performance data)"),
     Option("no-logs", None, False, "do not copy the monitoring history and log files"),
-    Option("no-past", "N", False, "do not copy RRD files, the monitoring history and log files"),
+    Option("no-agents", None, False, "do not copy agent files created by the agent bakery"),
+    Option("no-past", "N", False, "do not copy RRD files, agent files the monitoring history and log files"),
 ]
 
 

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3867,7 +3867,7 @@ exclude_options = [
         "no-past",
         "N",
         False,
-        "do not copy RRD files, agent files, the monitoring history and log files",
+        "do not copy RRD files, agent files, the monitoring history, and log files",
     ),
 ]
 

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3863,7 +3863,12 @@ exclude_options = [
     Option("no-rrds", None, False, "do not copy RRD files (performance data)"),
     Option("no-logs", None, False, "do not copy the monitoring history and log files"),
     Option("no-agents", None, False, "do not copy agent files created by the agent bakery"),
-    Option("no-past", "N", False, "do not copy RRD files, agent files the monitoring history and log files"),
+    Option(
+        "no-past", 
+        "N", 
+        False, 
+        "do not copy RRD files, agent files the monitoring history and log files"
+    ),
 ]
 
 

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3864,9 +3864,9 @@ exclude_options = [
     Option("no-logs", None, False, "do not copy the monitoring history and log files"),
     Option("no-agents", None, False, "do not copy agent files created by the agent bakery"),
     Option(
-        "no-past", 
-        "N", 
-        False, 
+        "no-past",
+        "N",
+        False,
         "do not copy RRD files, agent files the monitoring history and log files"
     ),
 ]


### PR DESCRIPTION
## General information

omd backup -N is a great way to get a small backup with only the config.
That is until one starts to use the bakery, the bakery can easily add gigabytes of data to the backup.
This PR introduces a feature to also exlude the baked agents

## Proposed changes


+ What is the expected behavior?
  Default behaviour of "omd backup" is unchanged
  however, when running with -N to get a small backup, var/check_mk/agents/* is excluded
 omd backup -h -> for help is also changed to reflect the changed behaviour

I think changing (or rather "enhancing") the default behaviour of -N makes sense, as the agents can easily be rebuilt and doing any backup with -N probably already means you really only want a config backup :) 

