### PR TITLE
Consider logged_out state before denying session init on user logon

### DIFF
--- a/cmk/gui/userdb/session.py
+++ b/cmk/gui/userdb/session.py
@@ -86,7 +86,7 @@ def ensure_user_can_init_session(username: UserId, now: datetime) -> None:
         return  # No login session limitation enabled, no validation
     for session_info in load_session_infos(username).values():
         idle_time = now.timestamp() - session_info.last_activity
-        if idle_time <= session_timeout:
+        if idle_time <= session_timeout and not session_info.logged_out:
             auth_logger.debug(
                 f"{username} another session is active (inactive for: {idle_time} seconds)"
             )


### PR DESCRIPTION
## General information

When configuring "Limit login to single session at a time" and then logging out, the user can not login again until the session time out (configured in the global setting) is reached. 

This is due to the fact, that when this setting is used, the "logged_out" attribute of the user's session info is never checked. 

This very short PR fixes this issue.

Affects at least 2.2-2.3 :) 

