### PR TITLE
Initialize "crit" var in liebert pump check to avoid crash in case device doesn't provide baseline

### DIFF
--- a/cmk/plugins/liebert/agent_based/liebert_pump.py
+++ b/cmk/plugins/liebert/agent_based/liebert_pump.py
@@ -43,6 +43,7 @@ def check_liebert_pump(item: str, section: Section[float]) -> CheckResult:
         return
 
     # TODO: this should be done in the parse function, per OID end.
+    crit = None
     for key, (c_value, _unit) in section.items():
         if "Threshold" in key and key.replace(" Threshold", "") == item:
             crit = c_value


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Extremely simple one-line fix to prevent the liebert_pump plugin from crashing due to "crit" being uninitialized, if the device does not have a threshold OID (as some in our environment do not). This is a re-submission of https://github.com/Checkmk/checkmk/pull/747 which I had inadvertently closed while reorganizing my local fork of the repo. Sorry!

## Bug reports

To reproduce, add a Liebert CRAC that reports pump hours over SNMP but does not provide a critical threshold over SNMP. This will cause the plugin to crash. The attached [CRAC2.txt](https://github.com/user-attachments/files/16604758/CRAC2.txt) is an SNMP walk that simulates one such device.

## Proposed changes

This plugin should, at the very least, initialize the crit variable, which will be used later (but has a possibility to not be set in the following loop).
