### PR TITLE
Change liebert fans check metrics to "fan_perc"

### DIFF
--- a/cmk/plugins/liebert/agent_based/liebert_fans.py
+++ b/cmk/plugins/liebert/agent_based/liebert_fans.py
@@ -40,7 +40,7 @@ def check_liebert_fans(
 
     yield from check_levels_v1(
         value,
-        metric_name="filehandler_perc",
+        metric_name="fan_perc",
         levels_lower=params.get("levels_lower"),
         levels_upper=params["levels"],
         render_func=lambda x: f"{x:.2f} {unit}",

--- a/cmk/plugins/liebert/agent_based/liebert_fans_condenser.py
+++ b/cmk/plugins/liebert/agent_based/liebert_fans_condenser.py
@@ -30,7 +30,7 @@ def check_liebert_fans_condenser(
         return
     yield from check_levels_v1(
         value,
-        metric_name="filehandler_perc",
+        metric_name="fan_perc",
         levels_lower=params.get("levels_lower"),
         levels_upper=params["levels"],
         render_func=lambda x: f"{x:.2f} {unit}",

--- a/cmk/plugins/liebert/agent_based/liebert_reheating.py
+++ b/cmk/plugins/liebert/agent_based/liebert_reheating.py
@@ -37,7 +37,7 @@ def check_liebert_reheating(params: Mapping[str, Any], section: Section[float]) 
     value, unit = data
     yield from check_levels_v1(
         value,
-        metric_name="filehandler_perc",
+        metric_name="fan_perc",
         levels_upper=params["levels"],
         render_func=lambda x: f"{x:.2f} {unit}",
     )


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Various liebert CRAC units with fans currently report fan status in "file handles." This is somewhat nonsensical. This pull request corrects these checks to use the "fan_perc" metric, in line with other checks that use fans.

## Proposed changes

This may cause issues with existing graphs, which are still in file_handles. At least on my system, the old graph remains with historical data, while a new graph with the expected "Fan Speed" metric also appears with new data.

I'm not sure of a simple way to fix this (or if it needs to be fixed), but I saw no mention of the issues from others, so I feel a decision should be made one way or the other.

Thank you for your consideration!