### PR TITLE
Fix: Exclude rotated or compressed logs from backup

### DIFF
--- a/omd/packages/omd/omdlib/backup.py
+++ b/omd/packages/omd/omdlib/backup.py
@@ -96,7 +96,7 @@ def get_exclude_patterns(options: CommandOptions) -> list[str]:
 
     if "no-logs" in options or "no-past" in options:
         # Logs of different components
-        excludes.append("var/log/*.log")
+        excludes.append("var/log/*.log*")
         excludes.append("var/log/*/*")
         excludes.append("var/pnp4nagios/log/*")
         excludes.append("var/pnp4nagios/perfdata.dump")


### PR DESCRIPTION
## General information

omd backup is excluding only current log files with --no-logs. It should exclude all existing log files.

## Bug reports

omd backup is used on linux distros and appliance. It behaves on all platform the same way.
If you create a backup with omd backup --no-logs only current log file is excluded. Rotated or
compressed log files will be added to backup. Those files should also be excluded.

## Proposed changes

Exclude from backups log files like
- liveproxyd.log.1
- liveproxyd.log.2.gz
- liveproxyd.log.3.gz
- dcd.log.1
- dcd.log.2.gz
- dcd.log.3.gz
- ...
