### PR TITLE
add Windows Server 2025 to rds_license check

### DIFF
--- a/cmk/base/legacy_checks/rds_licenses.py
+++ b/cmk/base/legacy_checks/rds_licenses.py
@@ -28,6 +28,7 @@ check_info = {}
 # Insert any new keys here
 # https://msdn.microsoft.com/en-us/library/aa383803%28v=vs.85%29.aspx#properties
 rds_licenses_product_versionid_map = {
+    "8": "Windows Server 2025",    
     "7": "Windows Server 2022",
     "6": "Windows Server 2019",
     "5": "Windows Server 2016",

--- a/cmk/base/legacy_checks/rds_licenses.py
+++ b/cmk/base/legacy_checks/rds_licenses.py
@@ -28,7 +28,7 @@ check_info = {}
 # Insert any new keys here
 # https://msdn.microsoft.com/en-us/library/aa383803%28v=vs.85%29.aspx#properties
 rds_licenses_product_versionid_map = {
-    "8": "Windows Server 2025",    
+    "8": "Windows Server 2025",
     "7": "Windows Server 2022",
     "6": "Windows Server 2019",
     "5": "Windows Server 2016",


### PR DESCRIPTION
Mapping for windows server 2025, not in microsoft docs yet, but seen in the wild

do you also accept pull requests for 2.3? it would be cool to also have this still in 2.3 :) 