### PR TITLE
Fix: Avoid Linux Agent timeouts when systemd-timedated doesn't run

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1628,7 +1628,7 @@ section_timesyncd() {
 
     echo "<<<timesyncd_ntpmessage:sep(10)>>>"
     timedatectl show-timesync | awk '/NTPMessage/{print $0}'
-    timedatectl show | awk '/Timezone/{print $0}'
+    timeout 5 timedatectl show | awk '/Timezone/{print $0}'
     return 0 # intended not to execute section_ntp even in the case where get_file_mtime fails
 }
 


### PR DESCRIPTION
## General information

See https://forum.checkmk.com/t/linux-agent-issues-with-systemd-timedated-service-creates-timeouts/52259 for context

## Bug reports

When the Linux agents checks systemd-timesync, it calls `timedatectl show`: https://github.com/Checkmk/checkmk/blob/86cbbd37f87b11f5a7fab9f7403d26a995da210d/agents/check_mk_agent.linux#L1631
When the service `systemd-timedated.service` doesn't run, the command times out and blocks the agent out for ~25 seconds:
````
# time timedatectl show
Failed to parse bus message: Connection timed out

real    0m25.020s
user    0m0.000s
sys     0m0.006s
# systemctl status systemd-timedated.service
● systemd-timedated.service - Time & Date Service
     Loaded: loaded (/lib/systemd/system/systemd-timedated.service; static)
     Active: failed (Result: exit-code) since Wed 2025-02-12 15:35:38 CET; 7s ago
````

25 seconds is nearly half of the default 60 seconds agent timeout, so the agent reaches this timeout sometimes when systemd-timedated is down.

## Proposed changes

Add a `timeout` call to reduce the timeout from `timedatectl show`  from ~25 seconds to 5 seconds.