### PR TITLE
invert ssl verify query

### DIFF
--- a/cmk/notification_plugins/sms_api.py
+++ b/cmk/notification_plugins/sms_api.py
@@ -134,7 +134,7 @@ def _get_request_params_from_context(
     return RequestParameter(
         recipient=recipient,
         url=raw_context["PARAMETER_URL"],
-        verify="PARAMETER_IGNORE_SSL" in raw_context,
+        verify="PARAMETER_IGNORE_SSL" not in raw_context,
         proxies=deserialize_http_proxy_config(
             raw_context.get("PARAMETER_PROXY_URL")
         ).to_requests_proxies(),


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

SMS Api with "Ignore to check SSL" fails because the query code is wrong.

## Bug reports

Please include:

+ Your operating system name and version
  + Ubuntu 24.04
+ Detailed steps to reproduce the bug
  + Configure Notification via SMS Api. Use https.
  + Tick "Disable SSL certificate verification"
  + Trigger a notification

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
  + Get the SMS notification
+ What is the observed behavior?
  + Error complaining about the ssl certificate
+ Workaround: Do not tick "Disable SSL certificate verification" and use https anyway
+ If it's not obvious from the above: In what way does your patch change the current behavior?
  + To ignore ssl verification - as the checkbox is meant to do
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
  + Migrating vom smstools to SMS Api
