### PR TITLE
add PGHOST variable to env files so mk_postgres can use type local co…

### DIFF
--- a/agents/plugins/mk_postgres.py
+++ b/agents/plugins/mk_postgres.py
@@ -1214,7 +1214,7 @@ def open_env_file(file_to_open):
 
 
 def parse_env_file(env_file):
-    # type: (str) -> tuple[str, str, str | None]
+    # type: (str) -> tuple[str, str, str | None, str]
     pg_port = None  # mandatory in env_file
     pg_database = "postgres"  # default value
     pg_version = None


### PR DESCRIPTION
## General information

This adds an optional `PGHOST` variable to the .env file of `mk_postgres.py`

It answers my own question at the [Checkmk forum](https://forum.checkmk.com/t/how-to-use-mk-postgres-py-plugin-when-postgres-only-listens-on-a-file-system-socket/52310).

This is useful when connecting to databases that only LISTEN on a socket and not on a TCP port. Set `PGHOST` to a directory where the socket `.s.PGSQL.$PGPORT` is located and you can use connections that are configured in `pg_hba.conf` as type `local`.

In theory you could also set `PGHOST` to the name of a remote host where a database resides. This might be useful in cases where you are not allowed to install a Checkmk agent on a database machine.

here is an example for monitoring a GitLab PostgreSQL instance:

postgres.sql:
```
DBUSER=gitlab-psql
PG_BINARY_PATH=/opt/gitlab/embedded/postgresql/14/bin/psql
INSTANCE=/etc/check_mk/gitlabhq_production.env:gitlab-psql::
```

gitlabhq_production.env:
```
PGDATABASE=gitlabhq_production
PGPORT=5432
PGHOST=/var/opt/gitlab/postgresql
```

Also I deleted the mentioning of `export` in the description of .env files. It created the false appearance that you could export environment variables to `mk_postgres.py`.