### PR TITLE
Added 'combined' to container_id options

### DIFF
--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -280,7 +280,7 @@ class MKDockerClient(docker.DockerClient):  # type: ignore[misc]
             self.all_containers = {c.attrs["Id"]: c for c in all_containers}
         elif config["container_id"] == "combined":
             self.all_containers = {
-                f'{os.uname()[1].split(".")[0]}_{c.attrs["Name"].lstrip("/")}': c
+                f"{os.uname()[1].split('.')[0]}_{c.attrs['Name'].lstrip('/')}": c
                 for c in all_containers
             }
         else:

--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -280,7 +280,8 @@ class MKDockerClient(docker.DockerClient):  # type: ignore[misc]
             self.all_containers = {c.attrs["Id"]: c for c in all_containers}
         elif config["container_id"] == "combined":
             self.all_containers = {
-                f'{os.uname()[1].split(".")[0]}_{c.attrs["Name"].lstrip("/")}': c for c in all_containers
+                f'{os.uname()[1].split(".")[0]}_{c.attrs["Name"].lstrip("/")}': c
+                for c in all_containers
             }
         else:
             self.all_containers = {c.attrs["Id"][:12]: c for c in all_containers}

--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -278,6 +278,10 @@ class MKDockerClient(docker.DockerClient):  # type: ignore[misc]
             self.all_containers = {c.attrs["Name"].lstrip("/"): c for c in all_containers}
         elif config["container_id"] == "long":
             self.all_containers = {c.attrs["Id"]: c for c in all_containers}
+        elif config["container_id"] == "combined":
+            self.all_containers = {
+                f'{os.uname()[1].split(".")[0]}_{c.attrs["Name"].lstrip("/")}': c for c in all_containers
+            }
         else:
             self.all_containers = {c.attrs["Id"][:12]: c for c in all_containers}
         self._env = {"REMOTE": os.getenv("REMOTE", "")}


### PR DESCRIPTION
### General information
This small changes adds the 'combined' option for container_id in the docker.cfg.
Output for the docker agent_based plugins does not change.
Replicates https://github.com/Checkmk/checkmk/pull/774 because I accidentally closed the previous pull request.

### Proposed changes
The corresponding config would look like this:

```
[DOCKER]
container_id: combined
and the result would be piggyback hosts with the scheme <hostname_of_docker_host>_<container_name>.
```

Ideas Portal suggestion: https://ideas.checkmk.com/suggestions/532086/include-hostname-in-container-name

Forum discussion: https://forum.checkmk.com/t/hostname-translation-for-piggyback/51039/8