### PR TITLE
Calix E7 can report "NOSUCHINSTANCE" for ifLastChange, which breaks i…

### DIFF
--- a/cmk/plugins/collection/agent_based/inv_if.py
+++ b/cmk/plugins/collection/agent_based/inv_if.py
@@ -82,7 +82,7 @@ def _process_sub_table(sub_table: Sequence[str | Sequence[int]]) -> Iterable[Int
 
     # Ignore useless entries for "TenGigabitEthernet2/1/21--Uncontrolled" (type) or half-empty
     # tables (e.g. Viprinet-Router)
-    if type_ in ("231", "232") or last_change in ("", "NULL") or not speed:
+    if type_ in ("231", "232") or last_change in ("", "NULL", "NOSUCHINSTANCE") or not speed:
         return
 
     yield Interface(


### PR DESCRIPTION
## General information

The Calix E7 is a carrier switch which hosts GPON cards to provide fiber to customer premises.

## Proposed changes

This change prevents a crash when running the HW/SW inventory on the Calix E7 carrier switch. This device returns interface sections which look like this:

['101',
   'Ethport 1/g1',
   'NOSUCHINSTANCE',
   '6',
   '1000000000',
   '1000',
   '2',
   '2',
   [78, 79, 83, 85, 67, 72, 73, 78, 83, 84, 65, 78, 67, 69],
   'NOSUCHINSTANCE'],

That 'NOSUCHINSTANCE' should be the IfLastChanged field, which inv_if.py seems to expect to be a valid time tuple or 'NULL' (in which case it sensibly and gracefully aborts). It should also abort for the case of this non-standard 'NOSUCHINSTANCE,' but right now it crashes, causing the whole inventory process to fail.

As an alternative, one might try to use is_digit() or a regex, or a try/catch block, but those might cause other issues and I thought it prudent to illustrate the problem with a minimal fix, for starters.

Thanks!
