### PR TITLE
mail loop: Don't send empty body

### DIFF
--- a/cmk/plugins/emailchecks/lib/connections.py
+++ b/cmk/plugins/emailchecks/lib/connections.py
@@ -304,7 +304,7 @@ class SMTP(_Connection):
     def _send_mail(
         self, subject: str, mail_from: str, mail_to: str, now: int, key: int
     ) -> tuple[str, MailID]:
-        mail = email.mime.text.MIMEText("")
+        mail = email.mime.text.MIMEText("Automatically sent by checkmk")
         mail["From"] = mail_from
         mail["To"] = mail_to
         mail["Subject"] = f"{subject} {now} {key}"


### PR DESCRIPTION
Most mail servers will flag the message as spam, because `COMPLETELY_EMPTY` will be flagged.



A message is should also be set, otherwise it is still flagged with `MISSING_MID`