### PR TITLE
mssql_jobs without a name

### DIFF
--- a/cmk/plugins/mssql/agent_based/mssql_jobs.py
+++ b/cmk/plugins/mssql/agent_based/mssql_jobs.py
@@ -192,7 +192,8 @@ def parse_mssql_jobs(string_table: StringTable) -> Mapping[str, JobSpec]:
 
 def discover_mssql_jobs(section: Mapping[str, JobSpec]) -> DiscoveryResult:
     for job_name in section:
-        yield Service(item=job_name)
+        if len(job_name) > 0:
+            yield Service(item=job_name)
 
 
 def check_mssql_jobs(


### PR DESCRIPTION
## General information

Some mssql_jobs may not have a name.

It occurred that some jobs do not have a name so that field is missing in the agent plugin output (_both, the deprecated mssql.vbs and the new mk-sql.exe_) and will be set to an empty string in the parsed output.

That leads to a discovery crash and all subsequent jobs will not be discovered as well, so I added the proof of the length of the job_name to keep the discovery from crashing.

Example agent plugin output of mk-sql.exe is attached.
[mssql_jobs.txt](https://github.com/user-attachments/files/18963422/mssql_jobs.txt)

