### PR TITLE
Update smart_posix to pass full command args

### DIFF
--- a/agents/plugins/smart_posix
+++ b/agents/plugins/smart_posix
@@ -21,10 +21,13 @@ main() {
         exit
     fi
     echo "<<<smart_posix_all:sep(0)>>>"
-    smartctl --scan | awk '{print $1}' | while read -r DEVICE; do
-        smartctl --all --json=c "$DEVICE"
-        printf "\n"
-    done
+    smartctl --scan | while IFS= read -r line; do
+        # Extract the part before the '#'
+        device_info=$(echo "$line" | cut -d '#' -f 1 | xargs)
+
+        # Run smartctl with the extracted device information
+        smartctl --all --json=c $device_info
+done
 }
 
 [ -z "${MK_SOURCE_ONLY}" ] && main

--- a/agents/plugins/smart_posix
+++ b/agents/plugins/smart_posix
@@ -27,7 +27,8 @@ main() {
 
         # Run smartctl with the extracted device information
         smartctl --all --json=c $device_info
-done
+        printf "\n"
+    done
 }
 
 [ -z "${MK_SOURCE_ONLY}" ] && main


### PR DESCRIPTION
## General information
detailed writeup https://forum.checkmk.com/t/smart-posix-in-master-branch-throws-errors-with-certain-drive-setups/52489

some setups (raid cards) would error with the just the device path being supplied to smartctl. the full args supplied by smartctl --scan should be used

## Proposed changes
pass the full args in from the output of smartctl --scan (split it at the first #)
