### PR TITLE
Extend interface discovery to allow discovery of multiple service labels

### DIFF
--- a/cmk/gui/plugins/wato/check_parameters/interfaces.py
+++ b/cmk/gui/plugins/wato/check_parameters/interfaces.py
@@ -70,6 +70,46 @@ def _vs_item_appearance(title, help_txt):
     )
 
 
+def _vs_labels_conditions():
+    return ListOf(
+        title=_("Generate service labels for discovered matching interfaces"),
+        help=_("Generate service labels based on matching conditions. All matching entries will add to the list of service labels."),
+        valuespec=Dictionary(
+            elements=[
+                (
+                    "conditions",
+                    Dictionary(
+                        title=_("Matching conditions"),
+                        elements=[
+                            (
+                                 "match_index",
+                                _vs_regex_matching("index"),
+                            ),
+                            (
+                                "match_alias",
+                                _vs_regex_matching("alias"),
+                            ),
+                            (
+                                "match_desc",
+                                _vs_regex_matching("description"),
+                            ),
+                        ],
+                    ),
+                ),
+                (
+                    "labels",
+                    Labels(
+                        world=Labels.World.CONFIG,
+                        label_source=Labels.Source.RULESET,
+                        title=_("Generate service labels"),
+                    ),
+                ),
+            ],
+        ),
+    )
+
+
+
 def _vs_single_discovery():
     return CascadingDropdown(
         title=_("Configure discovery of single interfaces"),
@@ -114,6 +154,10 @@ def _vs_single_discovery():
                                 title=_("Generate service labels for discovered interfaces"),
                             ),
                         ),
+                        (
+                            "labels_conditions",
+                            _vs_labels_conditions(),
+                        )
                     ],
                     optional_keys=["labels"],
                 ),

--- a/cmk/plugins/lib/interfaces.py
+++ b/cmk/plugins/lib/interfaces.py
@@ -1212,13 +1212,23 @@ def discover_interfaces(
             except (TypeError, ValueError):
                 index_as_item = False
 
+            labels = {}
+            if labels_conditions := single_interface_settings.get("labels_conditions"):
+                for labels_condition in labels_conditions:
+                    conditions = labels_condition.get("conditions", {})
+                    if check_regex_match_conditions(interface.attributes.index, conditions.get("match_index")) and check_regex_match_conditions(interface.attributes.alias, conditions.get("match_alias")) and check_regex_match_conditions(interface.attributes.descr, conditions.get("match_desc")):
+                        for k,v in labels_condition.get("labels").items():
+                            labels[k] = v
+            for k,v in single_interface_settings.get("labels", {}).items():
+                labels[k] = v
+
             pre_inventory.append(
                 (
                     item,
                     discovered_params_single,
                     int(interface.attributes.index),
                     index_as_item,
-                    single_interface_settings.get("labels"),
+                    labels,
                 )
             )
             seen_indices.add(interface.attributes.index)


### PR DESCRIPTION
## General information
This changes the Interface Discovery Ruleset and the Discovery itself to allow multiple service labels with individual matching conditions to be defined in a single rule.

## Proposed changes
Prior to this the discovery ruleset only allowed a list of service labels that would be discovered if the "Conditions for this rule to apply" would apply. If you would want to discover multiple service labels based on different conditions, you would need multiple rules and with any one additional service label the amount of rules would be increasing exponentially.

This request introduces an additional setting, that extends the service label discovery by allowing multiple sets of service labels with explicit matching conditions (index, alias and description):
![if_discovery](https://github.com/user-attachments/assets/77fa5d4f-71f0-4c0b-9fa9-2b210e83abb7)

