### PR TITLE
Fixed BI aggregation icon for use with password store

### DIFF
--- a/cmk/gui/bi/_icons.py
+++ b/cmk/gui/bi/_icons.py
@@ -96,11 +96,16 @@ class AggregationIcon(Icon):
         ):
             command = row["service_check_command"]
             args = shlex.split(command)
-            base_url = args[1]
+            if "stored_passwords" in args[0]:
+                base_url = args[2]
+                aggr_name = args[4]
+            else:
+                base_url = args[1]
+                aggr_name = args[3]
+
             base_url = base_url.replace("$HOSTADDRESS$", row["host_address"])
             base_url = base_url.replace("$HOSTNAME$", row["host_name"])
 
-            aggr_name = args[3]
             aggr_name = aggr_name.replace("$HOSTADDRESS$", row["host_address"])
             aggr_name = aggr_name.replace("$HOSTNAME$", row["host_name"])
 


### PR DESCRIPTION
Fixed aggregation icon for use with password store

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Link to BI aggregation was incorrect, if password store was used.

## Bug reports

Please include:

+ Your operating system name and version
Ubuntu 24.04
+ Any details about your local setup that might be helpful in troubleshooting
Nothing special
+ Detailed steps to reproduce the bug
Command for active check check_mk_active-bi_aggr was not correctly evaluated by aggregation icon
+ An agent output or SNMP walk
N. a.
+ The ID of a submitted crash report for reference (if applicable)
N. a.

## Proposed changes
Merge pull request

I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.