### PR TITLE
netapp_ontap_snapvault: Add transfer state

### DIFF
--- a/cmk/plugins/netapp/agent_based/netapp_ontap_snapvault.py
+++ b/cmk/plugins/netapp/agent_based/netapp_ontap_snapvault.py
@@ -28,6 +28,7 @@ from cmk.plugins.netapp import models
 #     "policy_type": "async",
 #     "source_svm_name": "mcc_darz_b_svm01_FC",
 #     "state": "snapmirrored",
+#     "transfer_state":"success",
 # }
 # {
 #     "destination": "mcc_darz_a_svm02_FC:vol_data1vg_dest",
@@ -36,6 +37,7 @@ from cmk.plugins.netapp import models
 #     "policy_type": "async",
 #     "source_svm_name": "mcc_darz_b_svm01_FC",
 #     "state": "snapmirrored",
+#     "transfer_state":"transferring",
 # }
 
 Section = Mapping[str, models.SnapMirrorModel]
@@ -88,6 +90,8 @@ def check_netapp_ontap_snapvault(
         yield Result(state=State.OK, summary=f"Destination-system: {snapvault.destination}")
     if snapvault.policy_name:
         yield Result(state=State.OK, summary=f"Policy: {snapvault.policy_name}")
+    if snapvault.transfer_state:
+        yield Result(state=State.OK, summary=f"Transfer State: {snapvault.transfer_state}")
     if snapvault.state:
         yield Result(state=State.OK, summary=f"State: {snapvault.state}")
 

--- a/cmk/plugins/netapp/models.py
+++ b/cmk/plugins/netapp/models.py
@@ -637,6 +637,7 @@ class SnapMirrorModel(BaseModel):
     policy_name: str | None = None
     policy_type: str
     state: str | None = None
+    transfer_state: str | None = None
     source_svm_name: str | None = None
     lag_time: datetime.timedelta | None = None
     destination: str

--- a/cmk/special_agents/agent_netapp_ontap.py
+++ b/cmk/special_agents/agent_netapp_ontap.py
@@ -744,6 +744,7 @@ def fetch_snapmirror(
 ) -> Iterable[models.SnapMirrorModel]:
     field_query = (
         "state",
+        "transfer.state",
         "policy.name",
         "policy.type",
         "source.svm.name",
@@ -763,6 +764,7 @@ def fetch_snapmirror(
             policy_name=element_data["policy"]["name"],
             policy_type=element_data["policy"]["type"],
             state=element_data.get("state"),
+            transfer_state=element_data["transfer"]["state"],
             source_svm_name=element_data["source"]["svm"]["name"],
             lag_time=element_data.get("lag_time"),
             destination=element_data["destination"]["path"],


### PR DESCRIPTION
## General information

Re-Add missing transfer state to NetApp SnapVault check

## Proposed changes

In the previous NetApp ONTAPI based check the transfer state was available, I just re-added that into the new REST based version. This helps to decide when a relation goes to WARN/CRIT which would be okay if the transfer is still ongoing. Forcing OK in this case was not in the previous version, so I didn't add it here.
