### PR TITLE
Update ps_section.py

### DIFF
--- a/cmk/plugins/collection/agent_based/ps_section.py
+++ b/cmk/plugins/collection/agent_based/ps_section.py
@@ -242,7 +242,7 @@ def parse_ps_lnx(string_table: StringTable) -> ps.Section | None:
 
 
 def _separate_sub_string_table(now: int, string_table: StringTable) -> tuple[int, StringTable]:
-    if string_table[0][0].startswith("[time]") and string_table[2][0].startswith("[processes]"):
+    if string_table and string_table[0][0].startswith("[time]") and string_table[2][0].startswith("[processes]"):
         return int(string_table[1][0]), string_table[3:]
     return now, string_table
 


### PR DESCRIPTION
## General information

Simply ignore empty string_table here to prevent crash of ps check.

That occured through a broken agent not returning all needed ps-Informations but checking the existance of the dictionary won't hurt otherwise and makes the code more rubust

## Bug reports

Crash report fcdadad2-0961-11f0-8161-ad7691f8c67a

## Proposed changes

Expected behaviour: be more resilient against broken agent input. Do not crash. Ignore it.

