### PR TITLE
Get GPU performance counters

### DIFF
--- a/cmk/special_agents/agent_vsphere.py
+++ b/cmk/special_agents/agent_vsphere.py
@@ -79,6 +79,13 @@ REQUESTED_COUNTERS_KEYS = (
     "datastore.sizeNormalizedDatastoreLatency",
     "datastore.datastoreReadIops",
     "datastore.datastoreWriteIops",
+    "gpu.mem.usage.average",
+    "gpu.mem.reserved.latest",
+    "gpu.power.used.latest",
+    "gpu.mem.total.latest",
+    "gpu.utilization.average",
+    "gpu.mem.used.average",
+    "gpu.temperature.average",
 )
 
 COOKIE_MAX_AGE_HOURS = 4


### PR DESCRIPTION
Get GPU performance counters

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

vSphre Special Agent could retieve GPU related data. Now there is no way to get GPU monitoring data from an esxi virtualization host. Retrieved data should be later processed by a variant of [agent-based/esx_vsphere_hostsystem_cpu_usage.py](https://github.com/Checkmk/checkmk/blob/master/cmk/plugins/vsphere/agent_based/esx_vsphere_hostsystem_cpu_usage.py).

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
vSphere special agent could retrieve GPU performance data
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
