### PR TITLE
Redfish patch1

### DIFF
--- a/cmk/plugins/redfish/agent_based/redfish_drives.py
+++ b/cmk/plugins/redfish/agent_based/redfish_drives.py
@@ -8,6 +8,7 @@ from cmk.agent_based.v2 import (
     CheckPlugin,
     CheckResult,
     DiscoveryResult,
+    Metric,
     Result,
     Service,
     State,
@@ -52,6 +53,7 @@ def check_redfish_drives(item: str, section: RedfishAPIData) -> CheckResult:
             disc_msg = (
                 f"{disc_msg}, Media Life Left: {int(data.get('PredictedMediaLifeLeftPercent', 0))}%"
             )
+            yield Metric("media_life_left", int(data.get("PredictedMediaLifeLeftPercent")))
         else:
             disc_msg = f"{disc_msg}, no SSD Media information available"
 

--- a/cmk/plugins/redfish/agent_based/redfish_drives.py
+++ b/cmk/plugins/redfish/agent_based/redfish_drives.py
@@ -30,6 +30,8 @@ def discovery_redfish_drives(section: RedfishAPIData) -> DiscoveryResult:
     for key in section.keys():
         if section[key].get("Status", {}).get("State") == "Absent":
             continue
+        if not section[key]["Name"]:
+            continue
         item = section[key].get("Id", "0") + "-" + section[key]["Name"]
         yield Service(item=item)
 

--- a/cmk/plugins/redfish/agent_based/redfish_physicaldrives.py
+++ b/cmk/plugins/redfish/agent_based/redfish_physicaldrives.py
@@ -67,11 +67,13 @@ def check_redfish_physicaldrives(item: str, section: RedfishAPIData) -> CheckRes
             disc_msg = (
                 f"{disc_msg}, Media Life Left: {int(data.get('PredictedMediaLifeLeftPercent', 0))}%"
             )
+            yield Metric("media_life_left", int(data.get("PredictedMediaLifeLeftPercent")))
         elif data.get("SSDEnduranceUtilizationPercentage"):
             disc_msg = (
                 f"{disc_msg}, SSD Utilization: "
                 f"{int(data.get('SSDEnduranceUtilizationPercentage', 0))}%"
             )
+            yield Metric("ssd_utilization", int(data.get("SSDEnduranceUtilizationPercentage")))
     yield Result(state=State(0), summary=disc_msg)
 
     dev_state, dev_msg = redfish_health_state(data.get("Status", {}))

--- a/cmk/plugins/redfish/graphing/ssddrives.py
+++ b/cmk/plugins/redfish/graphing/ssddrives.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Checkmk GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+"""Metric definition for SSDs"""
+
+from cmk.graphing.v1 import metrics, Title
+
+metric_media_life_left = metrics.Metric(
+    name="media_life_left",
+    title=Title("Predicted Media Life Left"),
+    unit=metrics.Unit(metrics.DecimalNotation("Percent")),
+    color=metrics.Color.GREEN,
+)
+
+metric_ssd_utilization = metrics.Metric(
+    name="ssd_utilization",
+    title=Title("SSD Endurance Utilization"),
+    unit=metrics.Unit(metrics.DecimalNotation("Percent")),
+    color=metrics.Color.GREEN,
+)


### PR DESCRIPTION
Upstream patch for all fixed inside Redfish 2.3 version
- ignore drives without name
- ssd life counters as metric
