### PR TITLE
Redfish patch2

### DIFF
--- a/cmk/plugins/redfish/agent_based/redfish_physicaldrives.py
+++ b/cmk/plugins/redfish/agent_based/redfish_physicaldrives.py
@@ -27,6 +27,12 @@ agent_section_redfish_physicaldrives = AgentSection(
 
 
 def _item_names(section: RedfishAPIData) -> dict:
+    """
+    Create a dictionary with the item name as key and the data as value.
+    The item name is created by concatenating the controller ID and the
+    Location or Name of the drive.
+    If the Location is empty, the Name is used.
+    """
     new_data = {}
     for _key, data in section.items():
         loc = data.get("Location")


### PR DESCRIPTION
Upstream patch for all fixed inside Redfish 2.3 version

- drive discovery on HPE drives also includes controller id in item
to prevent same item name for different drives

Incompatible change - rediscovery needed
