### PR TITLE
Redfish patch3

### DIFF
--- a/cmk/plugins/redfish/agent_based/inv_redfish_firmware.py
+++ b/cmk/plugins/redfish/agent_based/inv_redfish_firmware.py
@@ -117,7 +117,7 @@ def check_redfish_firmware(section: RedfishAPIData) -> CheckResult:
             continue
         component_name = _item_name(entry, padding)
         comp_state, comp_msg = redfish_health_state(entry.get("Status", {}))
-        if entry.get("Status", {}).get("State", "UNKNOWN") == "StandbyOffline":
+        if entry.get("Status", {}).get("State", "UNKNOWN") in ["StandbyOffline", "Disabled"]:
             comp_state = 0
         overall_state = max(overall_state, comp_state)
         if comp_state != 0:

--- a/cmk/plugins/redfish/agent_based/redfish_system.py
+++ b/cmk/plugins/redfish/agent_based/redfish_system.py
@@ -46,6 +46,12 @@ def check_redfish_system(item: str, section: SectionSystem) -> CheckResult:
     message = f"System with SerialNr: {data.get('SerialNumber')}, has State: {state_text}"
 
     yield Result(state=State(result_state), summary=message)
+    try:
+        service_tag = data.get("Oem", {}).get("Dell", {}).get("DellSystem", {}).get("ChassisServiceTag")
+        if service_tag:
+            yield Result(state=State(0), notice="placeholder text", details=f"Service Tag: {service_tag}")
+    except AttributeError:
+        pass
 
 
 check_plugin_redfish_system = CheckPlugin(

--- a/cmk/plugins/redfish/agent_based/redfish_system.py
+++ b/cmk/plugins/redfish/agent_based/redfish_system.py
@@ -47,9 +47,13 @@ def check_redfish_system(item: str, section: SectionSystem) -> CheckResult:
 
     yield Result(state=State(result_state), summary=message)
     try:
-        service_tag = data.get("Oem", {}).get("Dell", {}).get("DellSystem", {}).get("ChassisServiceTag")
+        service_tag = (
+            data.get("Oem", {}).get("Dell", {}).get("DellSystem", {}).get("ChassisServiceTag")
+        )
         if service_tag:
-            yield Result(state=State(0), notice="placeholder text", details=f"Service Tag: {service_tag}")
+            yield Result(
+                state=State(0), notice="placeholder text", details=f"Service Tag: {service_tag}"
+            )
     except AttributeError:
         pass
 

--- a/cmk/plugins/redfish/special_agents/agent_redfish.py
+++ b/cmk/plugins/redfish/special_agents/agent_redfish.py
@@ -453,8 +453,10 @@ def detect_vendor(root_data: Mapping[str, Any]) -> Vendor:
             vendor_data = Vendor(name="HPE", expand_string="?$expand=.")
             if vendor_string in ["Hp"]:
                 vendor_data.expand_string = ""
-            manager_data = root_data.get("Oem", {}).get(vendor_string, {}).get("Manager", {})[0]
+            manager_data = root_data.get("Oem", {}).get(vendor_string, {}).get("Manager", [])
             if manager_data:
+                manager_data = manager_data[0]
+            if isinstance(manager_data, dict):
                 vendor_data.version = manager_data.get("ManagerType")
                 if vendor_data.version is None:
                     vendor_data.version = (


### PR DESCRIPTION
Upstream patch for all fixed inside Redfish 2.3 version

Some small fixes and enhancements
- service tag for Dell devices included inside the System state Details
- firmware state disabled is ok
- fixed bug for HPE devices without manager in data
