### PR TITLE
Redfish patch4

### DIFF
--- a/cmk/plugins/redfish/agent_based/redfish_memory_summary.py
+++ b/cmk/plugins/redfish/agent_based/redfish_memory_summary.py
@@ -18,11 +18,25 @@ from cmk.plugins.redfish.lib import (
 
 
 def discover_redfish_memory_summary(section: SectionSystem) -> DiscoveryResult:
-    yield from (Service(item=item) for item in section)
+    if len(section) == 1:
+        if not list(section.values())[0].get("MemorySummary", {}):
+            return
+        yield Service(item="Summary")
+    else:
+        for item, data in section.items():
+            if not data.get("MemorySummary", {}):
+                continue
+            yield Service(item=f"Summary {item}")
 
 
 def check_redfish_memory_summary(item: str, section: SectionSystem) -> CheckResult:
-    if not (result := section.get(item)):
+    result = {}
+    if len(section) == 1:
+        result = list(section.values())[0].get("MemorySummary", {})
+    else:
+        systemid = item.split(" ")[-1]
+        result = section.get(systemid, {}).get("MemorySummary", {})
+    if not result:
         return
 
     state = result.get("Status", {"Health": "Unknown"})
@@ -34,7 +48,7 @@ def check_redfish_memory_summary(item: str, section: SectionSystem) -> CheckResu
 
 check_plugin_redfish_memory_summary = CheckPlugin(
     name="redfish_memory_summary",
-    service_name="Memory Summary %s",
+    service_name="Memory %s",
     sections=["redfish_system"],
     discovery_function=discover_redfish_memory_summary,
     check_function=check_redfish_memory_summary,


### PR DESCRIPTION
After testing the current 2.4 version i found one bug that was introduced at mainlining time.

Affected is the memory_summary service.
This patch fixes the problem and brings back the 2.3 behavior.
