### PR TITLE
Add subject into body for chains that require mail body

### DIFF
--- a/cmk/plugins/emailchecks/lib/connections.py
+++ b/cmk/plugins/emailchecks/lib/connections.py
@@ -187,9 +187,11 @@ class EWS(_Connection):
         self, subject: str, mail_from: str, mail_to: str, now: int, key: int
     ) -> tuple[str, MailID]:
         """Send an email with provided content using EWS and provided oauth"""
+        subject = f"{subject} {now} {key}"
         m = EWSMessage(
             account=self._account,
-            subject=f"{subject} {now} {key}",
+            subject=subject,
+            body=subject,
             author=mail_from,
             to_recipients=[mail_to],
         )
@@ -304,10 +306,11 @@ class SMTP(_Connection):
     def _send_mail(
         self, subject: str, mail_from: str, mail_to: str, now: int, key: int
     ) -> tuple[str, MailID]:
-        mail = email.mime.text.MIMEText("")
+        subject = f"{subject} {now} {key}"
+        mail = email.mime.text.MIMEText(subject)
         mail["From"] = mail_from
         mail["To"] = mail_to
-        mail["Subject"] = f"{subject} {now} {key}"
+        mail["Subject"] = subject
         mail["Date"] = email.utils.formatdate(localtime=True)
 
         logging.debug(


### PR DESCRIPTION
## Proposed changes

check_mail_loop currently sends mails with an empty body and all info in the subject, this commit changes this so that the same string is also used as the body of the mail.

There are 2 reasons for this:

1. e-mails with an empty body are sometimes viewed as suspicious and might get stuck in e-mail security solutions
2. when the mail is passed through an sms gateway that can/will only forward the e-mail body as an sms text, usually this would break the mail loop, with this tiny change, the default check_mail_loop can still be used.
(the same change in utils/mailbox.py in 2.3 is working in our customer production already.)

drawbacks:
 - a few bytes more? :) 
