### PR TITLE
[PVE] Monitor node status when using QDevice.

### DIFF
--- a/cmk/base/legacy_checks/pvecm_nodes.py
+++ b/cmk/base/legacy_checks/pvecm_nodes.py
@@ -46,6 +46,17 @@
 #          3          1 hp3
 #          4          1 hp4
 
+# Version >2 with QDevcie
+# <<<pvecm_nodes>>>
+#
+# Membership information
+# ~~~~~~~~~~~~~~~~~~~~~~
+#     Nodeid      Votes    Qdevice Name
+#          1          1    A,V,NMW hp1 (local)
+#          2          1    A,V,NMW hp2
+#          0          1            QDevice
+#
+
 
 # mypy: disable-error-code="var-annotated"
 
@@ -68,6 +79,11 @@ def parse_pvecm_nodes(string_table):
             parse_func = _parse_version_gt_2
             continue
 
+        if line == ["Nodeid", "Votes", "Qdevice", "Name"]:
+            header = ["node_id", "votes", "qdevice" "name"]
+            parse_func = _parse_version_gt_2_with_qdevice
+            continue
+
         if header is None:
             continue
 
@@ -86,6 +102,14 @@ def _parse_version_eq_2(line, header):
 
 def _parse_version_gt_2(line, header):
     return " ".join(line[2:]), dict(zip(header[:2], line[:2]))
+
+
+def _parse_version_gt_2_with_qdevice(line, header):
+    if len(line) > 3:
+        name = " ".join(line[3:])
+    else:
+        name = line[2] # QDevice
+    return name, dict(zip(header[:3], line[:3]))
 
 
 def inventory_pvecm_nodes(parsed):


### PR DESCRIPTION
## General information
When adding a QDevice to Proxmox VE to reach quorum (usually when having an even number of hosts), pvecm shows more info which currently cannot be parsed. Allow parsing this variant as well.

The CheckMK agent's output looks like this after adding a QDevice:
```
<<<pvecm_nodes>>>

Membership information
----------------------
    Nodeid      Votes    Qdevice Name
         1          1    A,V,NMW vm1 (local)
         2          1    A,V,NMW vm2
         0          1            Qdevice
```
With this patch, it'll show the nodes as expected:
![image](https://github.com/user-attachments/assets/affbc75b-f08f-40be-a8e5-d1fbfb692e6c)

Without this patch, the services just vanished after adding the Qdevice, due to a parsing error.
