### PR TITLE
Before using the ipmitool check if IPMI hardware exists

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -944,11 +944,12 @@ section_kernel() {
 }
 
 section_ipmitool() {
-    if inpath ipmitool; then
-        _run_cached_internal "ipmi" 300 300 900 600 "echo '<<<ipmi:sep(124)>>>'; waitmax 300 ipmitool sensor list | grep -v 'command failed' | grep -v -E '^[^ ]+ na ' | grep -v ' discrete '"
-        # readable discrete sensor states
-        _run_cached_internal "ipmi_discrete" 300 300 900 600 "echo '<<<ipmi_discrete:sep(124)>>>'; waitmax 300 ipmitool sdr elist compact"
-    fi
+    # Even if ipmitool is installed make sure that IPMI is really supported by your hardware.
+    inpath ipmitool && ls /dev/ipmi* &>/dev/null || return
+
+    _run_cached_internal "ipmi" 300 300 900 600 "echo '<<<ipmi:sep(124)>>>'; waitmax 300 ipmitool sensor list | grep -v 'command failed' | grep -v -E '^[^ ]+ na ' | grep -v ' discrete '"
+    # readable discrete sensor states
+    _run_cached_internal "ipmi_discrete" 300 300 900 600 "echo '<<<ipmi_discrete:sep(124)>>>'; waitmax 300 ipmitool sdr elist compact"
 }
 
 section_ipmisensors() {

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -635,11 +635,12 @@ section_kernel() {
 
 section_ipmitool() {
     # Hardware sensors via IPMI (need ipmitool)
-    if inpath ipmitool; then
-        _run_cached_internal "ipmi" 300 300 900 600 "echo <<<ipmi:sep(124)>>>; waitmax 300 ipmitool sensor list | grep -v 'command failed' | grep -v -E '^[^ ]+ na ' | grep -v ' discrete '"
-        # readable discrete sensor states
-        _run_cached_internal "ipmi_discrete" 300 300 900 600 "echo <<<ipmi_discrete:sep(124)>>>; waitmax 300 ipmitool sdr elist compact"
-    fi
+    # Even if ipmitool is installed make sure that IPMI is really supported by your hardware.
+    inpath ipmitool && ls /dev/ipmi* 2>/dev/null 1>&2 || return
+
+    _run_cached_internal "ipmi" 300 300 900 600 "echo <<<ipmi:sep(124)>>>; waitmax 300 ipmitool sensor list | grep -v 'command failed' | grep -v -E '^[^ ]+ na ' | grep -v ' discrete '"
+    # readable discrete sensor states
+    _run_cached_internal "ipmi_discrete" 300 300 900 600 "echo <<<ipmi_discrete:sep(124)>>>; waitmax 300 ipmitool sdr elist compact"
 }
 
 section_ipmisensors() { # keep in sync with linux agent


### PR DESCRIPTION
## General information

On some linux systems ipmitool is installed as a dependency without the hardware having an IPMI device. This change generates the ipmi section only if IPMI devices exis (similar to ipmi_sensors)

## Bug reports

Affected OSes:
- SLES 12/15
- RHEL 8/9
- Ubuntu 22.04/24.04

Steps to reproduce the bug:
Install ipmitool on a virual machine without /dev/ipmi* or in a container that is monitored by the linux agent

## Proposed changes

+ What is the expected behavior?
Same as for the ipmi_sensors section: check for IPMI devices before running the ipmitool

+ What is the observed behavior?
ipmitool is always run when found

+ If it's not obvious from the above: In what way does your patch change the current behavior?
This makes the ipmi-section behave like the ipmi_sensors-section already does. It checks for /dev/ipmi*
