### PR TITLE
Escape square brackets in paths in mk_inventory.ps1

### DIFF
--- a/agents/windows/plugins/mk_inventory.ps1
+++ b/agents/windows/plugins/mk_inventory.ps1
@@ -286,17 +286,19 @@ function getSoftwareFromRegistry {
                 $booleanContent = $false
 
                 foreach ($var in $regVars) {
+                    $escpspath = $subkey.PSPath
+                    $escpspath = $escpspath -replace '([][[])', '`$1' # escape square brackets
                     if ($var -eq "PSChildName") {
                         $value = $subkey.PSChildName
                     }
                     elseif ($var -eq "Language") {
-                        $value = (Get-ItemProperty -Path $subkey.PSPath -Name $var -ErrorAction SilentlyContinue).$var
+                        $value = (Get-ItemProperty -Path $escpspath -Name $var -ErrorAction SilentlyContinue).$var
                         if ($null -ne $value) {
                             $value = $value.ToString()
                         }
                     }
                     else {
-                        $value = (Get-ItemProperty -Path $subkey.PSPath -Name $var -ErrorAction SilentlyContinue).$var
+                        $value = (Get-ItemProperty -Path $escpspath -Name $var -ErrorAction SilentlyContinue).$var
                     }
 
                     if ($null -ne $value -and $value -is [string]) {


### PR DESCRIPTION
Fixes crashes for software with square brackets in their names.
