### PR TITLE
Fix: Missing spaces in help text.

### DIFF
--- a/cmk/gui/wato/_check_mk_configuration.py
+++ b/cmk/gui/wato/_check_mk_configuration.py
@@ -2229,8 +2229,8 @@ ConfigVariableSessionManagement = ConfigVariable(
                                 display=["minutes", "hours", "days"],
                                 minvalue=60,
                                 help=_(
-                                    "Warn the user at a specificied time before"
-                                    "the maximum session duration is reached"
+                                    "Warn the user at a specificied time before "
+                                    "the maximum session duration is reached "
                                     "to aid users in preserving data.",
                                 ),
                                 default_value=900,


### PR DESCRIPTION
## Proposed changes

Fix missing spaces in the help text of "Global settings" - "User management" - "Session management".