### PR TITLE
ovs_bonding: fix typo in the spelling of interface

### DIFF
--- a/cmk/plugins/collection/agent_based/ovs_bonding.py
+++ b/cmk/plugins/collection/agent_based/ovs_bonding.py
@@ -42,7 +42,7 @@ def parse_ovs_bonding(string_table: StringTable) -> bonding.Section:
                 raise InvalidOvsBondingStringTable("Missing bond value.")
 
             case _ if not last_interface:
-                raise InvalidOvsBondingStringTable("Missing slave inteface value.")
+                raise InvalidOvsBondingStringTable("Missing slave interface value.")
 
     parsed: dict[str, bonding.Bond] = {}
 


### PR DESCRIPTION
## General information

Just an obvious typo fix.

## Bug reports
- none

## Proposed changes

Fix a simple typo, seen when reporting a problem (for reference https://forum.checkmk.com/t/checkmk-2-4-0-parsing-of-section-ovs-bonding-failed/53745)
