### PR TITLE
Avoid crash on failure to parse int in emerson_temp discovery.

### DIFF
--- a/cmk/base/legacy_checks/emerson_temp.py
+++ b/cmk/base/legacy_checks/emerson_temp.py
@@ -40,7 +40,9 @@ def check_emerson_temp(item, params, info):
 
 
 def parse_emerson_temp(string_table: StringTable) -> StringTable:
-    return [[x] for x in string_table[0]]
+    # Only use the first two sensor values, as values beyond that seem to be handled in a different
+    # structure that we lack a concrete definition for.
+    return string_table[:2]
 
 
 check_info["emerson_temp"] = LegacyCheckDefinition(
@@ -49,7 +51,7 @@ check_info["emerson_temp"] = LegacyCheckDefinition(
     detect=startswith(".1.3.6.1.4.1.6302.2.1.1.1.0", "Emerson Network Power"),
     fetch=SNMPTree(
         base=".1.3.6.1.4.1.6302.2.1.2",
-        oids=["7.1", "7.2"],
+        oids=["7"],
     ),
     service_name="Temperature %s",
     discovery_function=inventory_emerson_temp,


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

While performing a discovery on certain Emerson/Vertiv devices, they can return an SNMP value to the generic Emerson temperature discovery function that cannot be parsed as an integer, causing this ValueError: 
[Checkmk_Crash_kale_lab_54b25f28-30d6-11f0-bf2f-005056a12db3_2025-05-14_11-46-04.tar.gz](https://github.com/user-attachments/files/20210740/Checkmk_Crash_kale_lab_54b25f28-30d6-11f0-bf2f-005056a12db3_2025-05-14_11-46-04.tar.gz)

This results in a perpetural state of "unknown" for the discovery service, and an accumulation of crash dumps: 
![2025-05-14 11_27_34-Checkmk Local site kale_lab - Services of host PTMONH07_VertivRectifier — Mozill](https://github.com/user-attachments/assets/d059210c-356a-4356-9add-850ecd33c08f)

## Proposed changes

There may be a better way to fix this, but it's difficult for me to know if e.g. changing the match string would break the original piece of hardware this check was written for. Python doesn't seem to have a quick or elegant way to comprehensively see if a string can be parsed as an integer other than to try and catch it if it fails, so that's what I opted for, here.

Thank you for your consideration!