### PR TITLE
netapp_ontap_status: Respect suppression and acknowledgements

### DIFF
--- a/cmk/plugins/netapp/models.py
+++ b/cmk/plugins/netapp/models.py
@@ -545,6 +545,10 @@ class AlertModel(BaseModel):
     """
 
     name: str
+    acknowledge: bool
+    acknowledger: str = ""
+    suppress: bool
+    suppressor: str = ""
 
 
 class SvmTrafficCountersModel(BaseModel):

--- a/tests/unit/cmk/plugins/netapp/agent_based/test_netapp_ontap_status.py
+++ b/tests/unit/cmk/plugins/netapp/agent_based/test_netapp_ontap_status.py
@@ -21,14 +21,41 @@ class AlertModelFactory(ModelFactory):
     "alerts_models, expected_result",
     [
         pytest.param(
-            [AlertModelFactory.build(name="alert1"), AlertModelFactory.build(name="alert2")],
-            [Result(state=State.CRIT, summary="Status: Alerts present")],
+            [
+                AlertModelFactory.build(name="alert1", acknowledge=False, suppress=False),
+                AlertModelFactory.build(name="alert2", acknowledge=False, suppress=False),
+            ],
+            [
+                Result(
+                    state=State.CRIT,
+                    summary="Unhandled alerts present, see details",
+                    details="alert1\nalert2",
+                )
+            ],
             id="alerts present",
         ),
         pytest.param(
             [],
-            [Result(state=State.OK, summary="Status: OK")],
+            [Result(state=State.OK, summary="No alerts present")],
             id="no alerts present",
+        ),
+        pytest.param(
+            [
+                AlertModelFactory.build(
+                    name="alert1", acknowledge=True, acknowledger="hhirsch", suppress=False
+                ),
+                AlertModelFactory.build(
+                    name="alert2", acknowledge=False, suppress=True, suppressor="hhirsch"
+                ),
+            ],
+            [
+                Result(
+                    state=State.OK,
+                    summary="Alerts present, but all acknowledged or suppressed, see details",
+                    details="alert1, acknowledged by hhirsch\nalert2, suppressed by hhirsch",
+                )
+            ],
+            id="alerts suppressed",
         ),
     ],
 )


### PR DESCRIPTION
Netapp allows to suppress and acknowledge alerts in its GUI. This change modifies netapp_ontap_status to consider all alerts that are either acknowledged or suppressed on the Netapp side as OK.

If alerts are present, but all are suppressed, these will be listed in the details.
