### PR TITLE
Fix: proper execution if DISABLE_CACHING enabled

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1691,7 +1691,7 @@ _run_cached_internal() {
     if ${DISABLE_CACHING:-false}; then
         # We need the re-splitting to be compatible with the caching case, so:
         # shellcheck disable=SC2068
-        $@
+        eval $@
         return
     fi
 


### PR DESCRIPTION
without eval not the entire command is executed, but only the first part

Example:

```
#!/bin/bash
# /tmp/test.sh
A="echo '<<<chrony>>>'; waitmax 5 chronyc -n tracking | cat || true"

$A
```

```bash
$ bash /tmp/test.sh
'<<<chrony>>>'; waitmax 5 chronyc -n tracking | cat || true
```

vs

```
#!/bin/bash
# /tmp/test.sh
A="echo '<<<chrony>>>'; waitmax 5 chronyc -n tracking | cat || true"

eval $A
```

```bash
$ bash /tmp/test.sh
<<<chrony>>>
Reference ID    : XXXXXXXXXXXXXXXXXXXXXXX
Stratum         : 3
Ref time (UTC)  : Wed May 28 13:44:12 2025
System time     : 0.000031057 seconds slow of NTP time
Last offset     : -0.000030625 seconds
RMS offset      : 0.000074238 seconds
Frequency       : 23.238 ppm fast
Residual freq   : -0.003 ppm
Skew            : 0.154 ppm
Root delay      : 0.011444902 seconds
Root dispersion : 0.000639769 seconds
Update interval : 258.2 seconds
Leap status     : Normal
```