### PR TITLE
Fix SuSE connect service, if data is missing (Branch 2.3.0)

### DIFF
--- a/cmk/base/legacy_checks/suseconnect.py
+++ b/cmk/base/legacy_checks/suseconnect.py
@@ -83,7 +83,12 @@ def check_suseconnect(_no_item, params, section: Section):
             state = 2
         yield state, infotext
 
-    if "subscription_type" in specs and "registration_code" in specs and "starts_at" in specs and "expires_at" in specs:
+    if (
+        "subscription_type" in specs
+        and "registration_code" in specs
+        and "starts_at" in specs
+        and "expires_at" in specs
+    ):
         yield (
             0,
             (

--- a/cmk/base/legacy_checks/suseconnect.py
+++ b/cmk/base/legacy_checks/suseconnect.py
@@ -68,49 +68,52 @@ def check_suseconnect(_no_item, params, section: Section):
     if (specs := get_data(section)) is None:
         return
 
-    state, infotext = 0, "Status: %(registration_status)s" % specs
-    if params["status"] != "Ignore" and params["status"] != specs["registration_status"]:
-        state = 2
-    yield state, infotext
-
-    state, infotext = 0, "Subscription: %(subscription_status)s" % specs
-    if (
-        params["subscription_status"] != "Ignore"
-        and params["subscription_status"] != specs["subscription_status"]
-    ):
-        state = 2
-    yield state, infotext
-
-    yield (
-        0,
-        (
-            "Subscription type: %(subscription_type)s, Registration code: %(registration_code)s, "
-            "Starts at: %(starts_at)s, Expires at: %(expires_at)s"
-        )
-        % specs,
-    )
-
-    expiration_date = time.strptime(specs["expires_at"], "%Y-%m-%d %H:%M:%S %Z")
-    expiration_time = time.mktime(expiration_date) - time.time()
-
-    if expiration_time > 0:
-        warn, crit = params["days_left"]
-        days2seconds = 24 * 60 * 60
-
-        if expiration_time <= crit * days2seconds:
+    if "registration_status" in specs:
+        state, infotext = 0, "Status: %s" % specs["registration_status"]
+        if params["status"] != "Ignore" and params["status"] != specs["registration_status"]:
             state = 2
-        elif expiration_time <= warn * days2seconds:
-            state = 1
-        else:
-            state = 0
-
-        infotext = "Expires in: %s" % render.timespan(expiration_time)
-        if state:
-            infotext += " (warn/crit at %d/%d days)" % (warn, crit)
-
         yield state, infotext
-    else:
-        yield 2, "Expired since: %s" % render.timespan(-1.0 * expiration_time)
+
+    if "subscription_status" in specs:
+        state, infotext = 0, "Subscription: %s" % specs["subscription_status"]
+        if (
+            params["subscription_status"] != "Ignore"
+            and params["subscription_status"] != specs["subscription_status"]
+        ):
+            state = 2
+        yield state, infotext
+
+    if "subscription_type" in specs and "registration_code" in specs and "starts_at" in specs and "expires_at" in specs:
+        yield (
+            0,
+            (
+                "Subscription type: %(subscription_type)s, Registration code: %(registration_code)s, "
+                "Starts at: %(starts_at)s, Expires at: %(expires_at)s"
+            )
+            % specs,
+        )
+
+        expiration_date = time.strptime(specs["expires_at"], "%Y-%m-%d %H:%M:%S %Z")
+        expiration_time = time.mktime(expiration_date) - time.time()
+
+        if expiration_time > 0:
+            warn, crit = params["days_left"]
+            days2seconds = 24 * 60 * 60
+
+            if expiration_time <= crit * days2seconds:
+                state = 2
+            elif expiration_time <= warn * days2seconds:
+                state = 1
+            else:
+                state = 0
+
+            infotext = "Expires in: %s" % render.timespan(expiration_time)
+            if state:
+                infotext += " (warn/crit at %d/%d days)" % (warn, crit)
+
+            yield state, infotext
+        else:
+            yield 2, "Expired since: %s" % render.timespan(-1.0 * expiration_time)
 
 
 check_info["suseconnect"] = LegacyCheckDefinition(


### PR DESCRIPTION
## General information
Customer is using CEE 2.3.0p30 and check crashes on SLES 15.6 systems.

## Bug reports
suseconnect is used on SLES 15.6 and should show state. Check crashes with information

File "/omd/sites/nagios/share/check_mk/checks/suseconnect", line 77, in check_suseconnect
state, infotext = 0, "Subscription: %(subscription_status)s" % specs
KeyError: subscription_status

## Proposed changes

Check was adapted to work as expected. Check was introduced for needed data.
Output has changed, so it makes sense to adapt the check.

Customer is using this version with any issues.