### PR TITLE
Fix SuSE connect service, if data is missing (Branch 2.4.0)

### DIFF
--- a/cmk/base/legacy_checks/suseconnect.py
+++ b/cmk/base/legacy_checks/suseconnect.py
@@ -84,7 +84,12 @@ def check_suseconnect(
             state = 2
         yield state, infotext
 
-    if "subscription_type" in specs and "registration_code" in specs and "starts_at" in specs and "expires_at" in specs:
+    if (
+        "subscription_type" in specs
+        and "registration_code" in specs
+        and "starts_at" in specs
+        and "expires_at" in specs
+    ):
         yield (
             0,
             (


### PR DESCRIPTION
## General information
Customer is using CEE 2.3.0p30 and check crashes on SLES 15.6 systems.
Customer will update to 2.4.0p2 soon. So it should be updated, too.

## Bug reports
suseconnect is used on SLES 15.6 and should show state. Check crashes with information

File "/omd/sites/nagios/share/check_mk/checks/suseconnect", line 77, in check_suseconnect
state, infotext = 0, "Subscription: %(subscription_status)s" % specs
KeyError: subscription_status

## Proposed changes

Check was adapted to work as expected. Check was introduced for needed data.
Output has changed, so it makes sense to adapt the check.

Customer is using this version with any issues.