### PR TITLE
adva_fsp_current: fix crit value

### DIFF
--- a/cmk/plugins/collection/agent_based/adva_fsp_current.py
+++ b/cmk/plugins/collection/agent_based/adva_fsp_current.py
@@ -39,7 +39,7 @@ def parse_adva_fsp_current(string_table: StringTable) -> Section:
     return {
         index_aid: SensorData(
             name=unit_name,
-            crit=float(current_str) / 1000.0,
+            crit=float(upper_threshold_str) / 1000.0,
             current=float(current_str) / 1000.0,
         )
         for current_str, upper_threshold_str, power_str, unit_name, index_aid in string_table


### PR DESCRIPTION
## General information
Affected devices: e.g. ADVA FSP 3000 F7

status quo: The "current_str” value is currently used for the values for CRIT/WARN.

The issue occurred during the migration of the check to the new Check API.

However, this is obviously incorrect, as the limits are always identical to the current value.

## Bug reports

Information about the system or setup should be unimportant, as the error can be reproduced completely independently of the setup.

## Proposed changes

This patch restores the previous status.