### PR TITLE
added ceph state active+undersized+degraded+remapped+backfill_wait+ba…

### DIFF
--- a/cmk/plugins/ceph/constants.py
+++ b/cmk/plugins/ceph/constants.py
@@ -51,6 +51,7 @@ PG_STATES: Final[frozenset[str]] = frozenset(
         "active+undersized+degraded+remapped+backfilling",
         "active+undersized+degraded+remapped+backfill_toofull",
         "active+undersized+degraded+remapped+backfill_wait",
+        "active+undersized+degraded+remapped+backfill_wait+backfill_toofull",
         "active+undersized+degraded+remapped+inconsistent+backfilling",
         "active+undersized+degraded+remapped+inconsistent+backfill_toofull",
         "active+undersized+degraded+remapped+inconsistent+backfill_wait",


### PR DESCRIPTION
## General information

The check for Ceph misses a PG state I received on a Ceph cluster.


## Proposed changes

Adding the state "active+undersized+degraded+remapped+backfill_wait+backfill_toofull" to the list of Ceph PG state constants.
