### PR TITLE
Added ability to watch logs in UNC paths under Windows

### DIFF
--- a/agents/plugins/mk_logwatch.py
+++ b/agents/plugins/mk_logwatch.py
@@ -293,7 +293,16 @@ def parse_filenames(line):
         _processed_line = line.replace("\\", "/")
         _processed_line = os.path.normpath(_processed_line)
         _processed_line = _processed_line.replace("\\", "\\\\")
-        return shlex.split(_processed_line)
+        _processed_line = shlex.split(_processed_line)
+
+        _new_processed_line = []
+        for element in _processed_line:
+            if element.startswith("\\"):
+                _new_processed_line.append(f"\\{element}")
+            else:
+                _new_processed_line.append(element)
+
+        return _new_processed_line
 
     if sys.version_info[0] < 3:
         return [x.decode("utf-8") for x in shlex.split(line.encode("utf-8"))]


### PR DESCRIPTION
## General information
This extends the functionality of mk_logwatch to watch logs located in UNC paths from a Windows host.

## Proposed changes
Prior to this, mk_logwatch was not able to watch logs located in UNC paths, as the processing of the config file ignored double backslashes. This PR doen't change anything with the processing, but it checks afterwards if a path begins with an backslash and simply adds another one:

![image](https://github.com/user-attachments/assets/1518ea13-214a-4e8c-b5b6-d14c0383dcdd)

