### PR TITLE
Added new host label "cmk/device_model" for SNMP devices

### DIFF
--- a/cmk/plugins/collection/agent_based/inventory_snmp_extended_info.py
+++ b/cmk/plugins/collection/agent_based/inventory_snmp_extended_info.py
@@ -16,6 +16,8 @@ from cmk.agent_based.v2 import (
     SNMPTree,
     StringTable,
     TableRow,
+    HostLabel,
+    HostLabelGenerator,
 )
 from cmk.plugins.lib.device_types import get_device_type_label
 
@@ -141,10 +143,19 @@ def _get_first_description(string_table: StringTable) -> str:
         return ""
 
 
+def host_label_snmp_extended_info(section: SNMPExtendedInfo) -> HostLabelGenerator:
+    yield from get_device_type_label(section)
+    if section.model:
+        yield HostLabel(
+            name="cmk/device_model",
+            value=section.model,
+        )
+
+
 snmp_section_snmp_extended_info = SimpleSNMPSection(
     name="snmp_extended_info",
     parse_function=parse_snmp_extended_info,
-    host_label_function=get_device_type_label,
+    host_label_function=host_label_snmp_extended_info,
     fetch=SNMPTree(
         base=".1.3.6.1.2.1.47.1.1.1.1",
         oids=[

--- a/cmk/plugins/collection/agent_based/inventory_snmp_extended_info.py
+++ b/cmk/plugins/collection/agent_based/inventory_snmp_extended_info.py
@@ -16,8 +16,6 @@ from cmk.agent_based.v2 import (
     SNMPTree,
     StringTable,
     TableRow,
-    HostLabel,
-    HostLabelGenerator,
 )
 from cmk.plugins.lib.device_types import get_device_type_label
 
@@ -143,19 +141,10 @@ def _get_first_description(string_table: StringTable) -> str:
         return ""
 
 
-def host_label_snmp_extended_info(section: SNMPExtendedInfo) -> HostLabelGenerator:
-    yield from get_device_type_label(section)
-    if section.model:
-        yield HostLabel(
-            name="cmk/device_model",
-            value=section.model,
-        )
-
-
 snmp_section_snmp_extended_info = SimpleSNMPSection(
     name="snmp_extended_info",
     parse_function=parse_snmp_extended_info,
-    host_label_function=host_label_snmp_extended_info,
+    host_label_function=get_device_type_label,
     fetch=SNMPTree(
         base=".1.3.6.1.2.1.47.1.1.1.1",
         oids=[

--- a/cmk/plugins/lib/device_types.py
+++ b/cmk/plugins/lib/device_types.py
@@ -32,6 +32,9 @@ def get_device_type_label(section: _WithDescription) -> HostLabelGenerator:
             * ups
             * wlc
 
+        cmk/device_model:
+            This label is set to the model extracted from the device sent via SNMP.
+
     """
     for device_type in SNMPDeviceType:
         if device_type.name in section.description.upper():
@@ -42,6 +45,9 @@ def get_device_type_label(section: _WithDescription) -> HostLabelGenerator:
             else:
                 yield HostLabel("cmk/device_type", device_type.name.lower())
             return
+        
+    if model := getattr(section, "model"):
+        yield HostLabel("cmk/device_model", model)
 
 
 # TODO: replace this by HostLabel instances.

--- a/tests/unit/cmk/plugins/collection/agent_based/test_section_host_label_doc.py
+++ b/tests/unit/cmk/plugins/collection/agent_based/test_section_host_label_doc.py
@@ -33,6 +33,7 @@ CRE_DOCUMENTED_BUILTIN_HOST_LABELS: Final = {
     "cmk/ceph/osd",
     "cmk/ceph/mon",
     "cmk/device_type",
+    "cmk/device_model",
     "cmk/docker_image",
     "cmk/docker_image_name",
     "cmk/docker_image_version",


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

This PR adds the new host label "cmk/device_model" to be discovered with SNMP devices. The value of it is the discovered model (if available).

## Proposed changes

The new host label extends the existing "cmk/device_type" label. This small addition enables administrators to differentiate more easily between devices and match them in rules:
![image](https://github.com/user-attachments/assets/5193ec39-0453-438a-8c6b-7095bbe0f348)