### PR TITLE
Changed comparison to upper case NODE names

### DIFF
--- a/cmk/plugins/collection/agent_based/aix_hacmp_nodes.py
+++ b/cmk/plugins/collection/agent_based/aix_hacmp_nodes.py
@@ -56,7 +56,7 @@ def parse_aix_hacmp_nodes(string_table):
         if len(line) == 1:
             parsed[line[0]] = {}
 
-        elif "NODE" in line[0]:
+        elif "NODE" in line[0].upper():
             if line[1].replace(":", "") in parsed:
                 node_name = line[1].replace(":", "")
                 get_details = True


### PR DESCRIPTION
Sometimes the cllsnode within the AIX Agent returns the nodes as "Node XYZ" so the node will not be discovered since the parsing function expects a strictly upper case "NODE" in the corresponding line of the agent output.

By changing the function as done the discovery of the nodes works as expected.