### PR TITLE
Add HOST_LABEL_<label> macro to BI search

### DIFF
--- a/cmk/bi/search.py
+++ b/cmk/bi/search.py
@@ -265,6 +265,8 @@ class BIHostSearch(ABCBISearch):
             }
             for idx, group in enumerate(search_match.match_groups):
                 search_result["$HOST_MG_%d$" % idx] = group
+            for key, value in search_match.host.labels.items():
+                search_result[f"HOST_LABEL_{key}"] = value
             search_results.append(search_result)
         return search_results
 


### PR DESCRIPTION
## General information

Add possibility to use host labels in the BI Search, making BI way more powerful and dynamic in large environments.
Existing BI-configurations are not affected.

All host labels of the found hosts will be available as a macro.

E.g. with the label customer/location:berlin the label value can dynamically be accessed (berlin in this case) via $HOST_LABEL_customer/location$.

![image](https://github.com/user-attachments/assets/bcb14efb-ce6e-4dc7-b274-df268bbd1fba)

