### PR TITLE
Add Freeipmi optional argument --ignore_unrecognized_events

### DIFF
--- a/cmk/plugins/ipmi/rulesets/special_agent.py
+++ b/cmk/plugins/ipmi/rulesets/special_agent.py
@@ -122,6 +122,14 @@ def _special_agents_ipmi_sensors_vs_freeipmi() -> Dictionary:
                     help_text=Help("Ignore not-available (i.e. N/A) sensors in output"),
                 ),
             ),
+            "ignore_unrecognized_events": DictElement(
+                required=False,
+                parameter_form=BooleanChoice(
+                    title=Title("Ignore unrecognized events"),
+                    label=Label("Enable"),
+                    help_text=Help("Ignore unrecognized events"),
+                ),
+            ),
         },
     )
 

--- a/cmk/plugins/ipmi/server_side_calls/special_agent.py
+++ b/cmk/plugins/ipmi/server_side_calls/special_agent.py
@@ -32,6 +32,7 @@ class _FreeIPMIParams(BaseModel, frozen=True):
     output_sensor_state: bool = True
     output_sensor_thresholds: bool = False
     ignore_not_available_sensors: bool = False
+    ignore_unrecognized_events: bool = False
     BMC_key: str | None = None
 
 
@@ -87,6 +88,7 @@ def _freeipmi_args(options: _FreeIPMIParams) -> Iterable[str]:
             ("--output_sensor_state", "output_sensor_state"),
             ("--ignore_not_available_sensors", "ignore_not_available_sensors"),
             ("--output_sensor_thresholds", "output_sensor_thresholds"),
+            ("--ignore_unrecognized_events", "ignore_unrecognized_events"),
         ]
         if getattr(options, checkbox)
     )

--- a/cmk/plugins/ipmi/special_agent/agent_ipmi_sensors.py
+++ b/cmk/plugins/ipmi/special_agent/agent_ipmi_sensors.py
@@ -95,6 +95,11 @@ def _add_freeipmi_args(subparsers: _SubParsersAction) -> None:
         action="store_true",
         help="Output sensor thresholds",
     )
+    parser_freeipmi.add_argument(
+        "--ignore_unrecognized_events",
+        action="store_true",
+        help="Ignore unrecognized events",
+    )
 
 
 def _add_ipmitool_args(subparsers: _SubParsersAction) -> None:
@@ -178,6 +183,7 @@ def _freeipmi_additional_args(
             "output_sensor_state",
             "ignore_not_available_sensors",
             "output_sensor_thresholds",
+            "ignore_unrecognized_events",
         ]
         if getattr(
             args,


### PR DESCRIPTION
## General information

This is about he integration “IPMI Sensors via Freeipmi or IPMItool“, using the freeipmi command. The freeipmi command has an argument `--ignore-unrecognized-events` but unfortunately this option is not available from WATO.

_nb: related ticket number: SUP-24124_

### Context:

We have recently onboarded new IPMI hosts into Checkmk, using “IPMI Sensors via Freeimpi” integration. The HW is from Supermicro.

Everything ok from monitoring point of view, except an alert on service “IPMI Sensor VBAT”:

> Status: battery presence detected' 'Unrecognized Event = 0100h' 'Unrecognized Event = 0200h' 'Unrecognized Event = 0400h' 'Unrecognized Event = 0800h' 'Unrecognized Event = 1000h' 'Unrecognized Event = 2000h' 'Unrecognized Event = 4000h

We checked on the system and could not find any issue reported. The only workaround we could think of is to disable monitoring of service “IPMI Sensor VBAT”. But using option --ignore-unrecognized-events appears to be better as status of VBAT is still monitored. With this option the service is:

> Status: battery presence detected


## Proposed changes

Add the option to enable agrument `--ignore-unrecognized-events` for freeipmi in WATO.

This PR adds this, in the same way as existing `--ignore-not-available-sensors`

The expected behavior is to have this option in ruleset _special_agents:ipmi_sensors_ selectable from the GUI. (default unselected).