### PR TITLE
agents/check_mk_agent.freebsd: add chrony

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -657,6 +657,11 @@ run_purely_synchronous_sections() {
         ntpq -np | sed -e 1,2d -e 's/^\(.\)/\1 /' -e 's/^ /%/'
     fi
 
+    if inpath chronyc; then
+        echo '<<<chrony>>>'
+        chronyc -n tracking | cat || true
+    fi
+
     # Number of TCP connections in the various states
     echo '<<<tcp_conn_stats>>>'
     netstat -na | awk ' /^tcp/ { c[$6]++; } END { for (x in c) { print x, c[x]; } }'


### PR DESCRIPTION
chrony is also available on freebsd and might be used instead of ntpd

i tested it with a [opnsense](https://github.com/rosa-Luxemburgstiftung-Berlin/ansible-opnsense-checkmk) and Checkmk Raw Edition 2.4.0p5

[service-2025-07-10_16-40-13.json](https://github.com/user-attachments/files/21167406/service-2025-07-10_16-40-13.json)
