### PR TITLE
Fix ups checks with Python ValueError exceptions

### DIFF
--- a/cmk/base/legacy_checks/ups_in_voltage.py
+++ b/cmk/base/legacy_checks/ups_in_voltage.py
@@ -13,7 +13,10 @@ check_info = {}
 
 
 def discover_ups_in_voltage(info):
-    yield from ((item, {}) for item, value in info if int(value) > 0)
+    try:
+        yield from ((item, {}) for item, value in info if int(value) > 0)
+    except ValueError:
+        pass
 
 
 def parse_ups_in_voltage(string_table: StringTable) -> StringTable:

--- a/cmk/base/legacy_checks/ups_out_voltage.py
+++ b/cmk/base/legacy_checks/ups_out_voltage.py
@@ -15,7 +15,14 @@ check_info = {}
 
 
 def discover_ups_out_voltage(info: list[list[str]]) -> Iterable[tuple[str, dict]]:
-    yield from ((item, {}) for item, value, *_rest in info if int(value) > 0)
+    for item, value, in info:
+        try:
+            value = int(value)
+        except ValueError:
+            value = 0
+
+        if value > 0:
+            yield (item, {})
 
 
 def parse_ups_out_voltage(string_table: StringTable) -> StringTable:

--- a/cmk/plugins/collection/agent_based/ups_out_load.py
+++ b/cmk/plugins/collection/agent_based/ups_out_load.py
@@ -34,7 +34,10 @@ Section = dict[str, UpsPowerVoltage]
 def int_or_zero(value: str) -> int:
     if value == "":
         return 0
-    return int(value)
+    try:
+        return int(value)
+    except ValueError:
+        return 0
 
 
 def parse_ups_load(string_table: Sequence[StringTable]) -> Section:


### PR DESCRIPTION
## General information

Checkmk 2.4.0p7 is used on Checkmk appliance 1.7.10.

ups check voltage in, ups voltage out and ups load out were not working and break down with exception ValueError.

## Bug reports

If a ups device configured and a discovery is done, then those checks will report this exception.

## Proposed changes

Take care about the value, which should be used for the check. In all cases a integer is return and check is working.