### PR TITLE
Changed stale section in css to make stale services more visible

### DIFF
--- a/packages/cmk-frontend/src/themes/facelift/scss/_status.scss
+++ b/packages/cmk-frontend/src/themes/facelift/scss/_status.scss
@@ -20,10 +20,10 @@
  * TODO: Get rid of important styles throughout this style sheet
  */
 
-.stale .state {
+.stale.state {
   text-shadow: none !important;
   background-image: none !important;
-  filter: saturate(50%) brightness(105%);
+  filter: saturate(10%) brightness(105%);
 }
 
 td.state {


### PR DESCRIPTION
## General information
This PR makes stale entities more visible by lowering the saturation.
My experience with people new to Checkmk (or that only use the GUI from time to time) is that stale services are often overlooked and not recognized. This change in the theme.css aims to help new / occasional users of Checkmk to distinguish more easily between normal and stale services.

## Proposed Changes
Before:
<img width="538" height="270" alt="image" src="https://github.com/user-attachments/assets/2b5f81fe-e1e0-4f72-81a4-c9f4367fd469" />

After:
<img width="454" height="263" alt="image" src="https://github.com/user-attachments/assets/8baf3ffa-120e-4a7b-8af5-c8ae91fe267e" />
