### PR TITLE
Special Agent Prometheus: fix agent_prometheus: error: the following arguments are required: --config

### DIFF
--- a/cmk/plugins/prometheus/special_agents/agent_prometheus.py
+++ b/cmk/plugins/prometheus/special_agents/agent_prometheus.py
@@ -904,10 +904,14 @@ class ApiError(Exception):
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
+
     config = sys.stdin.read()
+
     if config:
-        argv += ["--config", config]
+        argv = ["--config", config] + argv
+
     args = parse_arguments(argv)
+
     try:
         config = ast.literal_eval(args.config)
         config_args = _extract_config_args(config)


### PR DESCRIPTION
## General information

Configuring Agent Prometheus with WATO and want to query the results from promQL. Check_MK Service shows
**the following arguments are required: --config**.

## Bug reports

Debian 12 with CEE 2.4.0p8 is used. 
Configured Agent Prometheus with WATO and try to query some data from.
Check_MK Service will show this error.
If executed on console, the same is happening.

## Proposed changes

Root cause is, that positional and optional arguments are mixed. Take care about positions and do not mix arguments.
Executing and argument parsing should work.