### PR TITLE
Fix false critical on OMD backup job when check is delayed with more than 30 seconds

### DIFF
--- a/cmk/plugins/checkmk/agent_based/mkbackup.py
+++ b/cmk/plugins/checkmk/agent_based/mkbackup.py
@@ -125,8 +125,10 @@ def check_mkbackup(job_state: JobData) -> CheckResult:
             yield Result(state=State.WARN, summary="Schedule is currently disabled")
 
         elif next_run is not None:
-            # add a 30 seconds buffer to prevent a critical when the backup is about to start
-            if next_run < time.time() + 30:
+            # add a 120 seconds buffer to prevent a critical when the backup is about to start
+            # 60 seconds in case the check before the backup is delayed and
+            # 60 seconds in case the mkbackup plugin doesn't update its state
+            if next_run < time.time() + 120:
                 state = State.CRIT
             else:
                 state = State.OK


### PR DESCRIPTION
There is already a partial fix in https://github.com/Checkmk/checkmk/pull/711

But issue still can happen if the CheckMK check runs delayed more 30 seconds. For example the scheduled backup is at 01:00:00, but the checkmk check for 00:59 happens at 00:59:46 for example. `next_run < time.time() + 30` will be true since the `next_run` time is still from yesterday's backup.

I think 60 seconds is enough buffer, but adding additional 60 just to be on the safe side. The `mkbackup` command is scheduled by cron and if it is known the upper bound of when the backup changes its status, then the buffer time can be lowered.