### PR TITLE
Update shebang for OS compatibility

### DIFF
--- a/agents/plugins/mk_mysql
+++ b/agents/plugins/mk_mysql
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2019 Checkmk GmbH - License: GNU General Public License v2
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.


### PR DESCRIPTION
Not all OSes has bash in the same location on the file system, for example FreeBSD uses /usr/local/bin/bash

Use env instead to find/execute bash in a way that is more-compatible with other OSes
