### PR TITLE
Special Agent Prometheus: fix authentication error. Parameter is parsed as reference not as value

### DIFF
--- a/cmk/plugins/prometheus/server_side_calls/special_agent.py
+++ b/cmk/plugins/prometheus/server_side_calls/special_agent.py
@@ -143,7 +143,7 @@ def _commands_function(
         case ("auth_token", AuthToken(token=token)):
             args += [
                 "auth_token",
-                "--token",
+                "--token-reference",
                 token,
             ]
     yield SpecialAgentCommand(command_arguments=args, stdin=stdin)

--- a/tests/unit/cmk/plugins/prometheus/server_side_calls/test_special_agent.py
+++ b/tests/unit/cmk/plugins/prometheus/server_side_calls/test_special_agent.py
@@ -93,7 +93,7 @@ from cmk.server_side_calls.v1 import HostConfig, IPv4Config, Secret, SpecialAgen
                     "--cert-server-name",
                     "host",
                     "auth_token",
-                    "--token",
+                    "--token-reference",
                     Secret(0),
                 ],
             ),


### PR DESCRIPTION
## General information

Special agent prometheus is using the reference to token as token value. Reference to value is not de referenced.

## Bug reports

Debian  12 with Checkmk 2.4.0p8.cee
Used Prometheus rule for setup and want to query some promeQL statements. Problem is, that authentication is not successful. 

## Proposed changes

Special agent is using specified token's reference directly as value. The reference is not de referenced to get the value.
Now it is using the value of the reference and authentication is successful.