### PR TITLE
Add check_disk_smb results handling

### DIFF
--- a/cmk/plugins/smb/lib/check_disk_smb.py
+++ b/cmk/plugins/smb/lib/check_disk_smb.py
@@ -312,6 +312,10 @@ def _extract_data_from_not_matching_lines(
     ErrorResult(state=2, summary='Connection to 192.168.0.11 failed')
     >>> _extract_data_from_not_matching_lines(["tree connect failed: NT_STATUS_BAD_NETWORK_NAME"], "hostname", "share")
     ErrorResult(state=2, summary='Invalid share name \\\\\\\\hostname\\\\share')
+    >>> _extract_data_from_not_matching_lines(["session setup failed: NT_STATUS_NO_LOGON_SERVERS"], "hostname", "share")
+    ErrorResult(state=2, summary='No logon server')
+    >>> _extract_data_from_not_matching_lines(["session setup failed: NT_STATUS_IO_TIMEOUT"], "hostname", "share")
+    ErrorResult(state=2, summary='Timeout')
     >>> _extract_data_from_not_matching_lines(["some other error"], "hostname", "share")
     ErrorResult(state=3, summary='Result from smbclient not suitable')
     """
@@ -330,6 +334,14 @@ def _extract_data_from_not_matching_lines(
         # invalid share name
         if re.search(r"(You specified an invalid share name|NT_STATUS_BAD_NETWORK_NAME)", line):
             return ErrorResult(2, f"Invalid share name \\\\{hostname}\\{share}")
+
+        # no logon server
+        if re.search(r"(No logon servers|NT_STATUS_NO_LOGON_SERVERS)", line):
+            return ErrorResult(2, "No logon server")
+
+        # time out
+        if re.search(r"(Timeout|NT_STATUS_IO_TIMEOUT)", line):
+            return ErrorResult(2, "Timeout")
 
     return ErrorResult(state, summary)
 


### PR DESCRIPTION
## General information

Some results of smbclient command in check_disk_smb returns default state UNKNOWN with summary "Result from smbclient not suitable". This PR adds handling of two additional results:

`NT_STATUS_NO_LOGON_SERVERS` => CRITICAL - No logon servers
`NT_STATUS_IO_TIMEOUT` => CRITICAL - Timeout

Default remains: UNKNOWN with summary "Result from smbclient not suitable".

## Context

A service SMB Share flapping between UNKNOWN and CRITICAL states as some smbclient results fall into default case:

<img width="811" height="275" alt="image" src="https://github.com/user-attachments/assets/6a55c038-2e25-4225-b83d-7e8f95b4cb09" />

The smbclient results have been identified as:

> session setup failed: NT_STATUS_NO_LOGON_SERVERS

> session setup failed: NT_STATUS_IO_TIMEOUT


## Proposed changes

Add conditional matching of the two identified results, in order for the service check to return dedicated state and summary.
The two new conditions are added after the existing ones, to avoid risk of altering existing conditions outcome. This is important for the NT_STATUS_IO_TIMEOUT, as connection issue could also contain error NT_STATUS_IO_TIMEOUT:

> do_connect: Connection to 172.xx.xx.xx failed (Error NT_STATUS_IO_TIMEOUT)

After change:

<img width="808" height="181" alt="image" src="https://github.com/user-attachments/assets/84c9dce9-d119-4122-9cb7-4c291d45aee6" />

