### PR TITLE
Fix apache_status.py for Python >= 3.13

### DIFF
--- a/agents/plugins/apache_status.py
+++ b/agents/plugins/apache_status.py
@@ -37,7 +37,7 @@ if sys.version_info < (2, 6):
     sys.exit(1)
 
 
-def urlopen_(request, timeout=5, cafile=None, context=None):
+def urlopen_(request, timeout=5, context=None):
     if sys.version_info[0] == 2:
         scheme = request.get_type()
     else:
@@ -45,7 +45,7 @@ def urlopen_(request, timeout=5, cafile=None, context=None):
     if scheme not in ["http", "https"]:
         raise ValueError("Scheme '%s' is not allowed" % scheme)
     return urlopen(  # nosec B310 # BNS:6b61d9
-        request, timeout=timeout, cafile=cafile, context=context
+        request, timeout=timeout, context=context
     )
 
 
@@ -211,6 +211,13 @@ def get_ssl_no_verify_context():
     return context
 
 
+def get_ssl_cafile_context(cafile):
+    import ssl
+
+    context = ssl.create_default_context(cafile=cafile)
+    return context
+
+
 def get_response_body(proto, cafile, address, portspec, page):
     response = get_response(proto, cafile, address, portspec, page)
     return response.read().decode(get_response_charset(response))
@@ -236,7 +243,7 @@ def get_response(proto, cafile, address, portspec, page):
     # Try to fetch the status page for each server
     try:
         if proto == "https" and cafile:
-            return urlopen_(request, cafile=cafile, timeout=5)
+            return urlopen_(request, context=get_ssl_cafile_context(cafile=cafile), timeout=5)
         if proto == "https" and is_local:
             return urlopen_with_ssl(request, timeout=5)
         return urlopen_(request, timeout=5)


### PR DESCRIPTION
## General information

The cafile parameter to urlopen has been deprecated and is now finally removed: https://github.com/python/cpython/issues/105382

ssl contexts are only available from 2.7.9 on, but since that is already used in get_ssl_no_verify_context(), I assume it is a good choice going forward.
https://docs.python.org/2.7/library/ssl.html#ssl.create_default_context

See also https://forum.checkmk.com/t/apache-status-plugin-not-working-on-debian-13-trixie/55294?u=schlarbm

## Bug reports

Please include:

**CMK version:** OMD - Open Monitoring Distribution Version 2.3.0p35.cee
**OS version:** Debian GNU/Linux 13 (trixie)


**Error message:**
```
$ MK_CONFDIR=/etc/check_mk/ /usr/lib/check_mk_agent/plugins/apache_status.py 
<<<apache_status:sep(124)>>>
Exception ([::1]:443): urlopen() got an unexpected keyword argument 'cafile'
Exception ([::1]:80): urlopen() got an unexpected keyword argument 'cafile'
```
Apparently this is because of https://github.com/python/cpython/issues/105382

## Proposed changes

ssl contexts are only available from 2.7.9 on, but since that is already used in get_ssl_no_verify_context(), I assume it is a good choice going forward.
https://docs.python.org/2.7/library/ssl.html#ssl.create_default_context