### PR TITLE
Add more memory types to MAP_TYPES_MEMORY in hp_proliant.py

### DIFF
--- a/cmk/plugins/lib/hp_proliant.py
+++ b/cmk/plugins/lib/hp_proliant.py
@@ -25,6 +25,9 @@ MAP_TYPES_MEMORY: Final = {
     "16": "DIMM FBD2",
     "17": "FB-DIMM DDR2",
     "18": "FB-DIMM DDR3",
+    "19": "DIMM DDR4",
+    "20": "HPE Specific",
+    "21": "DIMM DDR5",
 }
 
 PRODUCT_NAME_OID = ".1.3.6.1.4.1.232.2.2.4.2.0"


### PR DESCRIPTION
Add more memory types (from cpqHeResMem2ModuleType in cpqhealth.mib)

These changes are from cpqhlth.mib in https://support.hpe.com/connect/s/softwaredetails?language=en_US&collectionId=MTX-85e329105f8e48d5&tab=releaseNotes
Download MIBKIT_2.7.0.0.exe archive, extract MIBKIT_GEN10_v2.7.0.0mib_l/cpqhlth.mib

This section is the same in the GEN10 and GEN11 subfolders:

```    cpqHeResMem2ModuleType OBJECT-TYPE
        SYNTAX  INTEGER {
                other(1),
                board(2),
                cpqSingleWidthModule(3),
                cpqDoubleWidthModule(4),
                simm(5),
                pcmcia(6),
                compaq-specific(7),
                dimm(8),
                smallOutlineDimm(9),
                rimm(10),
                srimm(11),
                fb-dimm(12),
                dimmddr(13),
                dimmddr2(14),
                dimmddr3(15),
                dimmfbd2(16),
                fb-dimmddr2(17),
                fb-dimmddr3(18),
                dimmddr4(19),
                hpe-specific(20),
                dimmddr5(21)
             }
        ACCESS  read-only
        STATUS  mandatory
        DESCRIPTION
            "Type of memory module installed.  The value other(1) will be
             given if the type is not known.  The value board(2) will be
             given if the memory module is permanently mounted (not modular)
             on a system board or memory expansion board."
        ::= { cpqHeResMem2ModuleEntry 7 }
```

I have added dimmddr4(19), hpe-specific(20), and dimmddr5(21), giving them more appropriate spaces/capitalisation