### PR TITLE
Fix missing previous xhardstate

### DIFF
--- a/notifications/templates/mail/bulk.html
+++ b/notifications/templates/mail/bulk.html
@@ -33,9 +33,9 @@
                                         display: inline-block;
                                         /* Inline block to respect width */">
                                 {% if service_notification %}
-                                    {{ entry.PREVIOUSSERVICEHARDSTATE[:4] }}
+                                    {{ (entry.PREVIOUSSERVICEHARDSTATE|default("NULL"))[:4] }}
                                 {% else %}
-                                    {{ entry.PREVIOUSHOSTHARDSTATE[:4] }}
+                                    {{ (entry.PREVIOUSHOSTHARDSTATE|default("NULL"))[:4] }}
                                 {% endif %}
                             </div>
                         </td>

--- a/notifications/templates/mail/bulk.html
+++ b/notifications/templates/mail/bulk.html
@@ -29,7 +29,7 @@
                         <td style="padding: 0; vertical-align: middle;">
                             <div class="mobile_event_marker_bulk"
                                  style="{{ macros.event_marker_bulk_style() }};
-                                        {% if service_notification %} {{ state_mapping[entry.PREVIOUSSERVICEHARDSTATE] }} {% else %} {{ state_mapping[entry.PREVIOUSHOSTHARDSTATE] }} {% endif %};
+                                        {% if service_notification %} {{ state_mapping[(entry.PREVIOUSSERVICEHARDSTATE|default('UNKNOWN'))] }} {% else %} {{ state_mapping[(entry.PREVIOUSHOSTHARDSTATE|default('UNKNOWN'))] }} {% endif %};
                                         display: inline-block;
                                         /* Inline block to respect width */">
                                 {% if service_notification %}

--- a/notifications/templates/mail/summary.html
+++ b/notifications/templates/mail/summary.html
@@ -33,7 +33,7 @@
                             <tr>
                                 <td style=" line-height: 45px; padding: 0; ">
                                     <div style="{{ macros.event_marker_style() }};
-                                                {% if service_notification %} {{ state_mapping[data.PREVIOUSSERVICEHARDSTATE] }} {% else %} {{ state_mapping[data.PREVIOUSHOSTHARDSTATE] }} {% endif %};
+                                                {% if service_notification %} {{ state_mapping[(data.PREVIOUSSERVICEHARDSTATE|default('UNKNOWN'))] }} {% else %} {{ state_mapping[(data.PREVIOUSHOSTHARDSTATE|default('UNKNOWN'))] }} {% endif %};
                                                 display: inline-block;
                                                 /* Inline block to respect width */">
                                         {% if service_notification %}

--- a/notifications/templates/mail/summary.html
+++ b/notifications/templates/mail/summary.html
@@ -37,9 +37,9 @@
                                                 display: inline-block;
                                                 /* Inline block to respect width */">
                                         {% if service_notification %}
-                                            {{ data.PREVIOUSSERVICEHARDSTATE[:4] }}
+                                            {{ (data.PREVIOUSSERVICEHARDSTATE|default("NULL"))[:4] }}
                                         {% else %}
-                                            {{ data.PREVIOUSHOSTHARDSHORTSTATE[:4] }}
+                                            {{ (data.PREVIOUSHOSTHARDSHORTSTATE|default("NULL"))[:4] }}
                                         {% endif %}
                                     </div>
                                 </td>


### PR DESCRIPTION
see #852 (closed by accident while trying to rebase to force pushes on master using the github UI)

# General information
Avoid failing notifications observed in the raw edition after upgrade to 2.4.x

# Bug reports
In some cases notifications will fail in the raw edition due to some missing VARs with the error
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'PREVIOUSSERVICEHARDSTATE'

It seems the bug affects raw and enterprise installations (see https://github.com/Checkmk/checkmk/pull/852#issuecomment-3301930581)

More details can be found in https://forum.checkmk.com/t/after-upgrade-from-2-3-x-to-2-4-x-raw-sporadically-failing-notifications-with-jinja2-exceptions-undefinederror-dict-object-has-no-attribute-previousservicehardstate/55347

# Proposed changes
The proposed changes just assure undefined values for the PREVIOUS[SERVICE|HOST]HARDSTATE in the jinja2 mail notification templates are set to some somehow sane defaults in order to avoid failing notifications.