### PR TITLE
add default value for MK_CONFDIR in ceph agent

### DIFF
--- a/cmk/plugins/ceph/agents/mk_ceph.py
+++ b/cmk/plugins/ceph/agents/mk_ceph.py
@@ -141,7 +141,7 @@ def main() -> int:
     except ImportError:
         return _bail_out_missing_dependency()
 
-    ceph_config, ceph_client = _load_plugin_config(os.environ["MK_CONFDIR"])
+    ceph_config, ceph_client = _load_plugin_config(os.environ.get("MK_CONFDIR", "/etc/ansible"))
 
     cluster = RadosCMD(Rados(conffile=ceph_config, name=ceph_client))
     cluster.client.connect()

--- a/cmk/plugins/ceph/agents/mk_ceph.py
+++ b/cmk/plugins/ceph/agents/mk_ceph.py
@@ -141,7 +141,7 @@ def main() -> int:
     except ImportError:
         return _bail_out_missing_dependency()
 
-    ceph_config, ceph_client = _load_plugin_config(os.environ.get("MK_CONFDIR", "/etc/ansible"))
+    ceph_config, ceph_client = _load_plugin_config(os.environ.get("MK_CONFDIR", "/etc/check_mk"))
 
     cluster = RadosCMD(Rados(conffile=ceph_config, name=ceph_client))
     cluster.client.connect()


### PR DESCRIPTION
## General information

This PR adds a default Value for the call on `MK_CONFDIR` in the ceph agent.

## Proposed changes

Add a default Value for the call of os.environ['MK_CONFDIR']
os.environ['MK_CONFDIR'] -> os.environ.get('MK_CONFDIR', "/etc/check_mk")

We've run into a issue where a few hosts were unable to read this environment variable, causing the mk_ceph.py agent to fail.
My guess is that such a default value is already present in other agents in some shape or form, as the mk_ceph.py agent was the only one to have failed.
