### PR TITLE
Proxmox_ve Agent crash from possible negative age value

### DIFF
--- a/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
+++ b/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
@@ -115,14 +115,16 @@ def check_proxmox_ve_vm_backup_status(
     # explicitly converted them to utc
     started_time = last_backup.get("started_time")
     if started_time:
-        yield from check_levels(
-            value=(now - started_time.astimezone(UTC)).total_seconds(),
-            levels_upper=params["age_levels_upper"],
-            metric_name="age",
-            render_func=render.timespan,
-            label="Age",
-            boundaries=(0, None),
-        )
+        age = (now - started_time.astimezone(UTC)).total_seconds()
+        if age >= 0:
+            yield from check_levels(
+                value=age,
+                levels_upper=params["age_levels_upper"],
+                metric_name="age",
+                render_func=render.timespan,
+                label="Age",
+                boundaries=(0, None),
+            )
     yield Result(
         state=State.OK,
         summary=f"Server local start time: {started_time}",


### PR DESCRIPTION
Possible negative value for backup age while backup is running, dont yield if it's negative

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

I noticed that during a running backup, the agent would crash for VMs that are configured for the piggyback data. From the crash report I went looking in the code and wrote this quick fix with which it works again, but was not able to figure out, why the value can be negative

## Bug reports

CheckMK is running on a Debian 13 Host and the agent is connecting to a Proxmox Cluster of 3 Nodes. While a backup job, including a monitored VM, is running, the check crashes.
ID of submitted crash report c39eb594-1edd-11f1-9a99-92000730c8a7