### PR TITLE
agents: fix lnx_bonding when no bonding interface is configured

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -857,7 +857,7 @@ section_bonding_interfaces() {
     (
         cd /proc/net/bonding 2>/dev/null || return
         echo '<<<lnx_bonding:sep(58)>>>'
-        head -v -n 1000 ./*
+        [ -n "$(ls)" ] && head -v -n 1000 ./*
     )
 }
 

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -581,7 +581,7 @@ section_bonding_interfaces() {
     (
         cd /proc/net/bonding 2>/dev/null || return
         echo '<<<lnx_bonding:sep(58)>>>'
-        head -v -n 1000 ./*
+        [ -n "$(ls)" ] && head -v -n 1000 ./*
     )
 }
 


### PR DESCRIPTION
## General information

When /proc/net/bonding exists but no bonding interface is configured, head fails with:

  head: *: No such file or directory

Fix this by checking if any interfaces exist before running head

## Bug reports
- Any Linux system with kmod-bonding loaded but no bonding interface configured (Tested on newest OpenWrt master)
- Reproduce: load bonding kernel module without configuring a bonding interface
- head fails with: `head: *: No such file or directory`

## Proposed changes
- Observed: head fails when /proc/net/bonding exists but is empty
- Expected: empty lnx_bonding section without errors
- Fix: check if interfaces exist before running head