### PR TITLE
Fix typo: powershel -> powershell

### DIFF
--- a/agents/wnx/install/resources/configure_and_exec.ps1
+++ b/agents/wnx/install/resources/configure_and_exec.ps1
@@ -2,7 +2,7 @@
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
 
-# Script to correctly configure defaults for other powershel scripts 
+# Script to correctly configure defaults for other powershell scripts 
 
 $executable = $args[0]
 $OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()

--- a/agents/wnx/x.cmd
+++ b/agents/wnx/x.cmd
@@ -1,2 +1,2 @@
-@rem Powershel wrapper to execute any file
+@rem Powershell wrapper to execute any file
 @powershell -ExecutionPolicy ByPass -File %*


### PR DESCRIPTION
Proposed change is to replace the typo `powershel` with `powershell`