### PR TITLE
Improve documentation for name parameter of NotificationParameters

### DIFF
--- a/packages/cmk-plugin-apis/cmk/rulesets/v1/rule_specs.py
+++ b/packages/cmk-plugin-apis/cmk/rulesets/v1/rule_specs.py
@@ -376,6 +376,7 @@ class NotificationParameters:
         topic: Categorization of the rule
         parameter_form: Configuration specification
         name: Identifier of the rule spec. Has to match the name of the notifications script
+              and be a valid, non-reserved Python identifier
         is_deprecated: Flag to indicate whether this rule is deprecated and should no longer be used
         help_text: Description to help the user with the configuration
     """


### PR DESCRIPTION
## General information

Minor improvement to the docstring of rulesets.v1.rule_specs.NotificationParameters

## Proposed changes

As opposed to the legacy API for notification parameters, NotificationParameters in the current API can no longer have identifiers such as notify-shmoo.py
The documentation is not clear about this, the resulting error in web.log upon trying to load such a param, however, is.

This change adds this rather useful bit of information to the documentation.
