### PR TITLE
return OK if backups for a VM are disabled

### DIFF
--- a/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
+++ b/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
@@ -50,7 +50,10 @@ def parse_proxmox_ve_vm_backup_status(
     string_table: StringTable,
 ) -> Section:
     result = BackupData()
-    backup_data = json.loads(string_table[0][0])["last_backup"] or {}
+
+    backup_json = json.loads(string_table[0][0])
+
+    backup_data = backup_json["last_backup"] or {}
     if "started_time" in backup_data:
         # the datetime object has timezone information
         result["started_time"] = datetime.strptime(
@@ -84,7 +87,10 @@ def parse_proxmox_ve_vm_backup_status(
         result["backup_time"] = float(backup_data["backup_time"])
     if "error" in backup_data:
         result["error"] = str(backup_data["error"])
-    return {"last_backup": result}
+
+    backup_enabled = bool(backup_json["backup_enabled"]) or False
+
+    return {"last_backup": result, "backup_enabled": backup_enabled}
 
 
 def discover_single(section: Section) -> DiscoveryResult:
@@ -100,7 +106,7 @@ def check_proxmox_ve_vm_backup_status(
     if not last_backup:
         yield (
             Result(state=State.CRIT, summary="No backup found")
-            if params["age_levels_upper"][0] == "fixed"
+            if params["age_levels_upper"][0] == "fixed" and section.get("backup_enabled")
             else Result(state=State.OK, summary="No backup found and none needed")  #
         )
         return

--- a/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
+++ b/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
@@ -50,9 +50,8 @@ def parse_proxmox_ve_vm_backup_status(
     string_table: StringTable,
 ) -> Section:
     result = BackupData()
-
+    
     backup_json = json.loads(string_table[0][0])
-
     backup_data = backup_json["last_backup"] or {}
     if "started_time" in backup_data:
         # the datetime object has timezone information

--- a/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
+++ b/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
@@ -43,14 +43,13 @@ class BackupData(TypedDict, total=False):
     error: str
 
 
-Section = Mapping[str, BackupData]
+Section = Mapping[str, BackupData | bool]
 
 
 def parse_proxmox_ve_vm_backup_status(
     string_table: StringTable,
 ) -> Section:
     result = BackupData()
-    
     backup_json = json.loads(string_table[0][0])
     backup_data = backup_json["last_backup"] or {}
     if "started_time" in backup_data:

--- a/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
+++ b/packages/cmk-plugins/cmk/plugins/proxmox_ve/agent_based/proxmox_ve_backup_status.py
@@ -43,7 +43,7 @@ class BackupData(TypedDict, total=False):
     error: str
 
 
-Section = Mapping[str, BackupData | bool]
+Section = Mapping[str, Any]
 
 
 def parse_proxmox_ve_vm_backup_status(

--- a/packages/cmk-plugins/cmk/plugins/proxmox_ve/special_agent/agent_proxmox_ve.py
+++ b/packages/cmk-plugins/cmk/plugins/proxmox_ve/special_agent/agent_proxmox_ve.py
@@ -348,6 +348,7 @@ def agent_proxmox_ve_main(args: argparse.Namespace) -> int:
             vm,
             config_lock_data,
             logged_backup_data,
+            vmid in backup_data["scheduled_vmids"],
             snapshot_data,
             node_cluster_mapping,
         ):
@@ -455,6 +456,7 @@ def _create_vm_sections(
     vm: Any,
     config_lock_data: Mapping[str, Mapping[str, str]],
     logged_backup_data: Mapping[str, object],
+    backup_enabled: bool,
     snapshot_data: Mapping[str, object],
     node_cluster_mapping: Mapping[str, object],
 ) -> Iterable[tuple[str, object]]:
@@ -519,6 +521,7 @@ def _create_vm_sections(
         {
             # todo: info about erroneous backups
             "last_backup": logged_backup_data.get(vmid),
+            "backup_enabled": backup_enabled,
         },
     )
     yield ("proxmox_ve_vm_snapshot_age", snapshot_data.get(vmid))


### PR DESCRIPTION
## General information

Affects: proxmox_ve_vm_backup_status

VMs with backups disabled return CRIT by default. As it is often intended to not backup VMs they shouldn't receive a CRIT warning by default.
I can understand why it could be beneficial to have CRIT for VMs where backups are disabled, but the warning should be created with dedicated text and be toggleable instead. 
This PR currently only includes a change to not have the status be Critical for VMs with backups disabled.

## Proposed changes

- add a 'backup_enabled' field to the output generated by the special agent per VM
- use the backup_enabled field to decide if no backups should cause a CRIT or OK Status

changes not in this PR that I could add if, as described above, VMs with backups disabled should return CRIT status:
- Add a third option to the check if no backups are found that can be seperately toggled so that disabled backups either results in a CRIT or OK Status
