### PR TITLE
fix: replace bare except with except BaseException in token_create

### DIFF
--- a/cmk/gui/dashboard/api/token_create.py
+++ b/cmk/gui/dashboard/api/token_create.py
@@ -64,7 +64,7 @@ def create_dashboard_token_v1(
     dashboard["public_token_id"] = token.token_id
     try:
         save_dashboard_to_file(api_context.config.sites, dashboard, body.dashboard_owner)
-    except:
+    except BaseException:
         # rollback token creation
         token_store.delete(token.token_id)
         raise


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except BaseException:` in `cmk/gui/dashboard/api/token_create.py` (PEP 8 E722).

**Why:** Bare `except:` is equivalent to `except BaseException:` but is less explicit. Since this block performs a rollback and re-raises, `except BaseException:` is the correct explicit form — it documents the intent to catch everything during the rollback.

**Change:**
```python
# Before
except:
    # rollback token creation
    token_store.delete(token.token_id)
    raise

# After
except BaseException:
    # rollback token creation
    token_store.delete(token.token_id)
    raise
```

## Testing
No behavior change — `except BaseException:` is semantically identical to `except:` but satisfies PEP 8 E722.