### PR TITLE
Fix: moving rulesets to bottom_of_folder within same folder via REST …

### DIFF
--- a/cmk/gui/watolib/rulesets.py
+++ b/cmk/gui/watolib/rulesets.py
@@ -1098,7 +1098,12 @@ class Ruleset:
     def move_rule_to(self, rule: Rule, *, index: int, use_git: bool) -> int:
         rules = self._rules[rule.folder.path()]
         old_index = rules.index(rule)
-        index = self.get_index_for_move(rule.folder, rule, index)
+
+        if index == Ruleset.BOTTOM:
+            index = len(rules) - 1
+        else:
+            index = self.get_index_for_move(rule.folder, rule, index)
+
         if old_index == index:
             return index
 


### PR DESCRIPTION
…API failed


When attempting to reorder rules within the same folder using the REST API, the position value bottom_of_folder did not behave as expected. Although the API returned a success response (HTTP 200), the rule order remained unchanged. In contrast, top_of_folder worked correctly.

The BOTTOM sentinel is now resolved to the correct target index (end of the list) before calling get_index_for_move(). This ensures consistent handling while keeping the existing logic structure intact.


I have read the CLA Document and I hereby sign the CLA or my organization already has a signed CLA.