### PR TITLE
Added service label cmk/mssql_recovery_type for mssql backup services

### DIFF
--- a/cmk/plugins/mssql/agent_based/backup.py
+++ b/cmk/plugins/mssql/agent_based/backup.py
@@ -20,6 +20,7 @@ from cmk.agent_based.v2 import (
     Service,
     State,
     StringTable,
+    ServiceLabel
 )
 
 # <<<mssql_backup>>>
@@ -61,6 +62,7 @@ class Backup(NamedTuple):
 
 
 Section = Mapping[str, Sequence[Backup]]
+SectionDatabases = dict[str, dict[str, str]]
 
 
 _MAP_BACKUP_TYPES = {
@@ -131,15 +133,26 @@ agent_section_mssql_backup = AgentSection(
 )
 
 
-def discover_mssql_backup(params: Mapping[str, Any], section: Section) -> DiscoveryResult:
+def discover_mssql_backup(params: Mapping[str, Any], section_mssql_backup: Section | None, section_mssql_databases: SectionDatabases | None) -> DiscoveryResult:
     if params["mode"] != "summary":
         return
-    for db_name in section:
-        yield Service(item=db_name)
+    for db_name in section_mssql_backup:
+        try:
+            yield Service(
+                item=db_name,
+                labels=[
+                    ServiceLabel(
+                        name="cmk/mssql_recovery_type",
+                        value=section_mssql_databases.get(db_name.split('MSSQL_')[1]).get("Recovery"),
+                    )
+                ]
+            )
+        except Exception:
+            yield Service(item=db_name)
 
 
-def check_mssql_backup(item: str, params: Mapping[str, Any], section: Section) -> CheckResult:
-    data = section.get(item)
+def check_mssql_backup(item: str, params: Mapping[str, Any], section_mssql_backup: Section | None, section_mssql_databases: SectionDatabases | None) -> CheckResult:
+    data = section_mssql_backup.get(item)
     if data is None:
         # Assume general connection problem to the database, which is reported
         # by the "X Instance" service and skip this check.
@@ -184,6 +197,7 @@ def check_mssql_backup(item: str, params: Mapping[str, Any], section: Section) -
 
 check_plugin_mssql_backup = CheckPlugin(
     name="mssql_backup",
+    sections=["mssql_backup", "mssql_databases"],
     service_name="MSSQL %s Backup",
     discovery_function=discover_mssql_backup,
     discovery_ruleset_name="discovery_mssql_backup",

--- a/cmk/plugins/mssql/agent_based/backup.py
+++ b/cmk/plugins/mssql/agent_based/backup.py
@@ -18,9 +18,9 @@ from cmk.agent_based.v2 import (
     render,
     Result,
     Service,
+    ServiceLabel,
     State,
     StringTable,
-    ServiceLabel
 )
 
 # <<<mssql_backup>>>
@@ -133,7 +133,11 @@ agent_section_mssql_backup = AgentSection(
 )
 
 
-def discover_mssql_backup(params: Mapping[str, Any], section_mssql_backup: Section | None, section_mssql_databases: SectionDatabases | None) -> DiscoveryResult:
+def discover_mssql_backup(
+    params: Mapping[str, Any],
+    section_mssql_backup: Section | None,
+    section_mssql_databases: SectionDatabases | None,
+) -> DiscoveryResult:
     if params["mode"] != "summary":
         return
     for db_name in section_mssql_backup:
@@ -143,15 +147,22 @@ def discover_mssql_backup(params: Mapping[str, Any], section_mssql_backup: Secti
                 labels=[
                     ServiceLabel(
                         name="cmk/mssql_recovery_type",
-                        value=section_mssql_databases.get(db_name.split('MSSQL_')[1]).get("Recovery"),
+                        value=section_mssql_databases.get(db_name.split("MSSQL_")[1]).get(
+                            "Recovery"
+                        ),
                     )
-                ]
+                ],
             )
         except Exception:
             yield Service(item=db_name)
 
 
-def check_mssql_backup(item: str, params: Mapping[str, Any], section_mssql_backup: Section | None, section_mssql_databases: SectionDatabases | None) -> CheckResult:
+def check_mssql_backup(
+    item: str,
+    params: Mapping[str, Any],
+    section_mssql_backup: Section | None,
+    section_mssql_databases: SectionDatabases | None,
+) -> CheckResult:
     data = section_mssql_backup.get(item)
     if data is None:
         # Assume general connection problem to the database, which is reported


### PR DESCRIPTION
## General information

This changes the MSSQL Backup service discovery to also discover a service label, based on the recovery type of the SQL instance.

## Proposed changes

Prior to this, the MSSQL Backup service would only discover the service. With this, there is a new service label being discovered for those services: "cmk/mssql_recovery_type":
<img width="846" height="182" alt="image" src="https://github.com/user-attachments/assets/2b5e92e7-21d0-4d03-9b9e-23408f96c374" />

This enables Checkmk administrators to easily set different thresholds for MSSQL backup services based on the recovery type. For example, Checkmk administrators can now create one rule that only matches on this host label, that disables thresholds for the Log backup on Instances with the recovery type SIMPLE.
Prior to this, such a rule would have to be set on each host and instance individually.