### PR TITLE
Added option to disable the discovery of disabled mssql jobs

### DIFF
--- a/cmk/plugins/mssql/agent_based/mssql_jobs.py
+++ b/cmk/plugins/mssql/agent_based/mssql_jobs.py
@@ -198,7 +198,7 @@ def discover_mssql_jobs(params: dict[str, bool], section: Mapping[str, JobSpec])
         if not params.get("discover_schedule_disabled") and not job_specs.schedule_enabled:
             continue
         else:
-             yield Service(item=job_name)
+            yield Service(item=job_name)
 
 
 def check_mssql_jobs(
@@ -261,5 +261,5 @@ check_plugin_mssql_jobs = CheckPlugin(
     discovery_ruleset_name="mssql_jobs_discovery",
     discovery_default_parameters={
         "discover_schedule_disabled": True,
-    }
+    },
 )

--- a/cmk/plugins/mssql/agent_based/mssql_jobs.py
+++ b/cmk/plugins/mssql/agent_based/mssql_jobs.py
@@ -193,10 +193,12 @@ def parse_mssql_jobs(string_table: StringTable) -> Mapping[str, JobSpec]:
     return section
 
 
-def discover_mssql_jobs(section: Mapping[str, JobSpec]) -> DiscoveryResult:
-    for job_name in section:
-        if job_name:
-            yield Service(item=job_name)
+def discover_mssql_jobs(params: dict[str, bool], section: Mapping[str, JobSpec]) -> DiscoveryResult:
+    for job_name, job_specs in section.items():
+        if not params.get("discover_schedule_disabled") and not job_specs.schedule_enabled:
+            continue
+        else:
+             yield Service(item=job_name)
 
 
 def check_mssql_jobs(
@@ -256,4 +258,8 @@ check_plugin_mssql_jobs = CheckPlugin(
         "status_disabled_schedule": 0,
         "status_missing_jobs": 2,
     },
+    discovery_ruleset_name="mssql_jobs_discovery",
+    discovery_default_parameters={
+        "discover_schedule_disabled": True,
+    }
 )

--- a/cmk/plugins/mssql/rulesets/mssql_jobs_discovery.py
+++ b/cmk/plugins/mssql/rulesets/mssql_jobs_discovery.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python3
 
 from cmk.rulesets.v1 import (
-    Title,
     Label,
+    Title,
 )
 
 from cmk.rulesets.v1.form_specs import (
-    Dictionary,
-    DictElement,
     BooleanChoice,
     DefaultValue,
+    DictElement,
+    Dictionary,
 )
 
 from cmk.rulesets.v1.rule_specs import (
-    Topic,
     DiscoveryParameters,
+    Topic,
 )
-
 
 
 def _parameter_form_mssql_jobs_discovery() -> Dictionary:
@@ -25,8 +24,7 @@ def _parameter_form_mssql_jobs_discovery() -> Dictionary:
         elements={
             "discover_schedule_disabled": DictElement(
                 parameter_form=BooleanChoice(
-                    label=Label("Discover jobs with disabled Scheduler"),
-                    prefill=DefaultValue(True)
+                    label=Label("Discover jobs with disabled Scheduler"), prefill=DefaultValue(True)
                 ),
                 required=True,
             ),

--- a/cmk/plugins/mssql/rulesets/mssql_jobs_discovery.py
+++ b/cmk/plugins/mssql/rulesets/mssql_jobs_discovery.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+from cmk.rulesets.v1 import (
+    Title,
+    Label,
+)
+
+from cmk.rulesets.v1.form_specs import (
+    Dictionary,
+    DictElement,
+    BooleanChoice,
+    DefaultValue,
+)
+
+from cmk.rulesets.v1.rule_specs import (
+    Topic,
+    DiscoveryParameters,
+)
+
+
+
+def _parameter_form_mssql_jobs_discovery() -> Dictionary:
+    return Dictionary(
+        title=Title("MSSQL Jobs Discovery"),
+        elements={
+            "discover_schedule_disabled": DictElement(
+                parameter_form=BooleanChoice(
+                    label=Label("Discover jobs with disabled Scheduler"),
+                    prefill=DefaultValue(True)
+                ),
+                required=True,
+            ),
+        },
+    )
+
+
+rule_spec_mssql_jobs_discovery = DiscoveryParameters(
+    name="mssql_jobs_discovery",
+    title=Title("MSSQL Jobs Discovery"),
+    topic=Topic.APPLICATIONS,
+    parameter_form=_parameter_form_mssql_jobs_discovery,
+)


### PR DESCRIPTION
## General information

This introduces a new discovery rule that enables Checkmk administrators to deactivate the discovery of disabled mssql jobs.


## Proposed changes

Until now, Checkmk tries to discover all MSSQL jobs. But this is often not wanted, as there can be old / unused jobs in the state disabled. So with this PR there comes a new discovery rule, that makes it possible to not discover those disabled jobs:
<img width="520" height="74" alt="image" src="https://github.com/user-attachments/assets/cfb4a308-1add-454b-b862-465c00ebf72c" />

The default behaviour of the discovery stays unchanged, this new rule is completely optional.