### PR TITLE
Update text formatting for trap OIDs

### DIFF
--- a/packages/cmk-ec/cmk/ec/main.py
+++ b/packages/cmk-ec/cmk/ec/main.py
@@ -1787,7 +1787,7 @@ def create_event_from_trap(trap: Iterable[tuple[str, str]], ipaddress_: str) -> 
         priority=5,  # notice
         facility=31,  # not used by syslog -> we use this for all traps
         application=scrub_string(trapOIDs[0][1] if trapOIDs else ""),
-        text=scrub_string(", ".join(f"{oid}: {value}" for oid, value in other)),
+        text="\x01".join(scrub_string(f"{oid}: {value}") for oid, value in other),
         core_host=None,
         host_in_downtime=False,
     )


### PR DESCRIPTION
ec: split SNMP trap varbinds across visual lines in event message

Trap events created from incoming SNMP traps concatenate all OID/value pairs into a single long line, which makes the Event Console message column hard to read when a trap carries many varbinds (typical for hardware traps from Dell iDRAC, HP iLO, Microsoft, VMware, etc.).

Use the existing "\x01" line-break marker convention instead of ", " as the separator between varbinds. The GUI painter for the event_text column already converts "\x01" into "<br>" at render time (see cmk/gui/mkeventd/views.py), so this produces a visual line break per varbind in the Event Console without changing the on-disk format in any incompatible way.

scrub_string() is applied per varbind rather than to the joined string, because it strips "\x01" (along with other control characters) to keep the line-oriented history files safe. Applying it before the join preserves the separator while still sanitising each individual OID/value pair.

Note for rule authors: rules matching the previous ", " separator in trap message text need to be updated, as varbinds are now separated by "\x01" internally.

<img width="1509" height="369" alt="image" src="https://github.com/user-attachments/assets/62208e23-ad6a-4a1e-bd2b-25cb12fd29e5" />


Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

- Your operating system name and version
- Any details about your local setup that might be helpful in troubleshooting
- Detailed steps to reproduce the bug
- An agent output or SNMP walk
- The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

- What is the expected behavior?
- What is the observed behavior?
- If it's not obvious from the above: In what way does your patch change the current behavior?
- Consider writing a unit test that would have failed without your fix.
- Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
