### PR TITLE
Change service name of Fritzbox check

### DIFF
--- a/cmk/plugins/fritzbox/agent_based/fritz.py
+++ b/cmk/plugins/fritzbox/agent_based/fritz.py
@@ -209,7 +209,7 @@ def check_fritz_uptime(
 check_plugin_fritz_uptime = CheckPlugin(
     name="fritz_uptime",
     sections=["fritz"],
-    service_name="Uptime",
+    service_name="Uptime WAN connection",
     discovery_function=discover_fritz_uptime,
     check_function=check_fritz_uptime,
     check_default_parameters={},

--- a/cmk/plugins/fritzbox/checkman/fritz_uptime
+++ b/cmk/plugins/fritzbox/checkman/fritz_uptime
@@ -4,7 +4,7 @@ catalog: hw/network/avm
 license: GPLv2
 distribution: check_mk
 description:
- This check monitors the uptime of the Fritz!Box.
+ This check monitors the uptime of the WAN connection.
 
 discovery:
  One service is created for each system if the agent has a section {<<<fritz>>>}


### PR DESCRIPTION
## General information

The Fritzbox plugin creates the service "Uptime" currently. This misleads to think that it shows the uptime of the device. But it reflects the uptime of the WAN connection.

## Proposed changes

Rename service "Uptime" to "Uptime of WAN connection"