### PR TITLE
Dockerfile: mount DEB sources instead of copy to reduce image size

### DIFF
--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -35,9 +35,6 @@ COPY docker-entrypoint.sh /
 # Starts the entrypoint script and hands over CMD by default
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-# Make the list of required packages available to the following command
-COPY needed-packages /needed-packages
-
 # Install the tools we need for fetching the package and installation
 # Then fetch the package and install it. This will make sure all Checkmk
 # containers will share all dependencies, including this step.
@@ -46,7 +43,8 @@ COPY needed-packages /needed-packages
 # be up-to-date, especially when they are pinned in our build environment.
 #
 # hadolint ignore=SC2046,DL3008
-RUN set -e \
+RUN --mount=type=bind,source=needed-packages,target=/needed-packages \
+    set -e \
     && echo "exit 101" > /usr/sbin/policy-rc.d \
     && chmod +x /usr/sbin/policy-rc.d \
     && export DEBIAN_FRONTEND=noninteractive \
@@ -70,7 +68,6 @@ RUN set -e \
     && apt-get clean \
     && rm /usr/sbin/policy-rc.d \
     && rm -rf /var/lib/apt/lists/* \
-    && rm needed-packages \
     && mv /etc/apt/sources.list.bak /etc/apt/sources.list
 
 # Pure build time variable declarations (docker build --build-arg KEY=val)
@@ -79,28 +76,24 @@ ARG CMK_EDITION
 # Distro codename is used to find the corresponding .deb package
 ARG DISTRO_CODENAME="jammy"
 
-# Optionally copy an existing Checkmk debian package to the container. In case the file is
-# available that is later used by the build procedure the file will not be downloaded.
-COPY check-mk-${CMK_EDITION}-${CMK_VERSION}_0.${DISTRO_CODENAME}*.deb Check_MK-pubkey.gpg /
-
 # Now install the Checkmk version specific things
 # hadolint ignore=DL3003,DL3008,DL4006
-RUN set -e \
+RUN --mount=type=bind,target=/source \
+    set -e \
     && mkdir -p /usr/share/man/man8 \
     && echo "exit 101" > /usr/sbin/policy-rc.d \
     && chmod +x /usr/sbin/policy-rc.d \
     && export DEBIAN_FRONTEND=noninteractive \
     && PKG_NAME="check-mk-${CMK_EDITION}-${CMK_VERSION}" \
     && PKG_FILE="${PKG_NAME}_0.${DISTRO_CODENAME}_$(dpkg --print-architecture).deb" \
-    && if [ ! -e "/${PKG_FILE}" ]; then \
+    && if [ ! -e "/source/${PKG_FILE}" ]; then \
         echo "ERROR: Please provide ${PKG_FILE} by downloading it from https://download.checkmk.com/checkmk" \
         && return 1 ; \
        fi \
-    && gpg -q --import "/Check_MK-pubkey.gpg" \
-    && gpg --verify "${PKG_FILE}" \
-    && dpkg -i "${PKG_FILE}" \
+    && gpg -q --import "/source/Check_MK-pubkey.gpg" \
+    && gpg --verify "/source/${PKG_FILE}" \
+    && dpkg -i "/source/${PKG_FILE}" \
     && dpkg -i "$(ls /omd/versions/default/share/check_mk/agents/check-mk-agent_*-1_all.deb)" \
-    && rm -f -- *.deb *.gpg \
     && apt-get clean \
     && rm /usr/sbin/policy-rc.d \
     && rm -rf /var/lib/apt/lists/*
@@ -112,3 +105,4 @@ LABEL \
     org.opencontainers.image.vendor="Checkmk GmbH" \
     org.opencontainers.image.source="https://github.com/checkmk/checkmk" \
     org.opencontainers.image.url="https://checkmk.com/"
+


### PR DESCRIPTION
## General information

This PR affects the Dockerfile and targets size reduction of the published images.

## Proposed changes

The DEB package is used temporarily and deleted after installation. The intermediate layer still exists which bloats the final image by about 300MB without any real benefit. The DEB file is deleted anyway, so the COPY layer is effectively hidden.

Mount (bind) the context directory to /source and drop the COPY layers to reduce the image size.

This feature requires _BuildKit_ or an equivalent platform that supports mounts. It is available since Docker v18.09 and default since v23.0 and should not be an issue in modern build environments.
(with older _Docker_ 18-22 `DOCKER_BUILDKIT=1` is required)

Reference: https://docs.docker.com/reference/dockerfile/#run---mounttypebind

### Additional notes

We mount the entire context using `RUN --mount,type=bind,target=/source` for the CMK installation. This could be narrowed down to mount only the required files (like we do for _needed-packages_), but the only difference here is cachng behavior.

Using other builders like rootless _Podman_ with _SELinux_ enabled, monting requires proper _container_file_t_ labels or relabelling (e.g. `--mount=type=bind,target=/source,relabel=private`). Using Docker/BuildKit or Buildah in most CI environments should be fine without.

----

Test build (using _Podman_ 5.8 on _Linux_). Upstream image for reference and two custom builds with/without optimization for comparison.

Size comparison

| REPOSITORY                           | TAG               | IMAGE ID     | SIZE    |
|--------------------------------------|-------------------|--------------|---------|
| docker.io/checkmk/check-mk-community | 2.5.0p1           | eddd8397d6ad | 2.24 GB |
| localhost/check-mk-community         | 2.5.0p1-original  | 9b2f4ff16b4b | 2.25 GB |
| localhost/check-mk-community         | 2.5.0p1-optimized | f381d5ee0f39 | 1.86 GB |

Layer history

| CREATED BY                                    | ID (orig)    | SIZE (orig) | ID           | SIZE    |
|-----------------------------------------------|--------------|-------------|--------------|---------|
| /bin/sh -c #(nop) LABEL     org.opencontai... | c87f42abd820 | 0 B         | f381d5ee0f39 | 0 B     |
| \|3 CMK_EDITION=community CMK_VERSION=2.5.0... |              | 1.53 GB     |              | 1.53 GB |
| /bin/sh -c #(nop) COPY multi:45ace9d0f9ad6... | 73e53d05d8c3 | 331 MB      | --           | --      |
| /bin/sh -c #(nop) ARG CMK_EDITION CMK_VERS... | c75640b6230b | 0 B         | 4a3a763caed1 | 0 B     |
| /bin/sh -c #(nop) ARG CMK_EDITION CMK_VERSION |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) ARG CMK_VERSION             |              | 0 B         |              | 0 B     |
| /bin/sh -c set -e     && echo "exit 101" >... |              | 309 MB      |              | 309 MB  |
| COPY file:12dbbdebed8418...                   | 1c00a30d8ffc | 2.05 kB     | --           | --      |
| ENTRYPOINT ["/docker-ent...                   | e9244ff50479 | 0 B         | e9244ff50479 | 0 B     |
| /bin/sh -c #(nop) COPY file:7ea8f45fd1a8a6... |              | 7.17 kB     |              | 7.17 kB |
| /bin/sh -c #(nop) ENV CMK_CONTAINERIZED="T... | 714d1a2f39e9 | 0 B         | 714d1a2f39e9 | 0 B     |
| /bin/sh -c #(nop) ENV TZ=""                   |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) ENV MAIL_RELAY_HOST=""      |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) ENV CMK_PASSWORD=""         |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) ENV CMK_LIVESTATUS_TCP=""   |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) ENV CMK_SITE_ID="cmk"       |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) HEALTHCHECK --interval=1... |              | 0 B         |              | 0 B     |
| /bin/sh -c #(nop) EXPOSE 5000 6557            |              | 0 B         |              | 0 B     |