### PR TITLE
Fix detection of HAProxy Enterprise

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1455,10 +1455,11 @@ section_proxmox() {
 
 section_haproxy() {
     # Consider sockets for community v2.x and v3.x AND enterprise edition
-    for HAPROXY_SOCK in /run/haproxy/admin.sock /var/lib/haproxy/stats /var/run/haproxy.sock /var/run/hapee-*/hapee-lb.sock; do
+    for HAPROXY_SOCK in /run/haproxy/admin.sock /var/lib/haproxy/stats /var/run/haproxy.sock {,/var}/run{,/hapee-*}/hapee-lb.sock; do
         if [ -r "${HAPROXY_SOCK}" ] && inpath socat; then
             echo "<<<haproxy:sep(44)>>>"
             echo "show stat" | socat - "UNIX-CONNECT:${HAPROXY_SOCK}"
+            break
         fi
     done
 }


### PR DESCRIPTION
## General information
With recent versions of HAProxy Enterprise (HAPEE) the socket is no more created in a hapee subdirectory. Also /var/run is often only a link to /run.

This change searches all currently known options and stops after the first socket found.

## Bug reports
- Agent OS: RHEL 9.7
- HAProxy Fusion 2.0
- HAProxy Enterprise 3.2
- Detailed steps to reproduce the bug: Just run the agent - haproxy is not detected

Fusion 2.0 generates a default configuration for hapee-lb using
```
stats socket /var/run/hapee-lb.sock
```
With /var/run being just a link the file is created as /run/hapee-lb.sock

## Proposed changes
- What is the expected behavior? Checkmk should work with the default configuration HAProxy Enterprise uses
- What is the observed behavior? HAPEE configuration needs to be modified to work with Checkmk
- If it's not obvious from the above: In what way does your patch change the current behavior? Extend the search path and stop when socket is found to avoid duplicate section output