### PR TITLE
Prepare for changes of su in util-linux 2.42

### DIFF
--- a/cmk/plugins/postgres/agents/mk_postgres.py
+++ b/cmk/plugins/postgres/agents/mk_postgres.py
@@ -793,10 +793,10 @@ class PostgresLinux(PostgresBase):
         # type: (str, str, str, bool, bool) -> str
         base_cmd_list = [
             "su",
-            "-",
-            self.db_user,
             "-c",
             r"""PGPASSFILE=%s %s -X %s -A0 -F'%s' -f %s""",
+            "--login",
+            self.db_user,
         ]
         extra_args += " -U %s" % self.pg_user
         extra_args += " -d %s" % self.pg_database
@@ -809,7 +809,7 @@ class PostgresLinux(PostgresBase):
         if rows_only:
             extra_args += " -t"
 
-        base_cmd_list[-1] = base_cmd_list[-1] % (
+        base_cmd_list[-3] = base_cmd_list[-3] % (
             self.pg_passfile,
             self.psql_binary_path,
             extra_args,


### PR DESCRIPTION
## General information

With util-linux 2.42 su gets more strict about it's command line. From the release notes:

> pass arguments after <user> to shell (by cgoesche)

It is also recommended to use "--login" instead of "-".



## Bug reports
mk_postgres.py does not work with util-linux 2.42 - see https://forum.checkmk.com/t/postgresql-services-disappear-after-updating-util-linux-to-2-42/58816

## Proposed changes

- change su argument order to match man page
- use recommended long form of `--login`
