### PR TITLE
Fix DCD crash in openapi validation if meta_data is null

### DIFF
--- a/cmk/gui/openapi/api_endpoints/models/attributes.py
+++ b/cmk/gui/openapi/api_endpoints/models/attributes.py
@@ -699,13 +699,21 @@ class MetaDataModel:
     @classmethod
     def from_internal(cls, value: MetaData) -> Self:
         return cls(
-            created_at=dt.datetime.fromtimestamp(value["created_at"])
-            if "created_at" in value
-            else ApiOmitted(),
-            updated_at=dt.datetime.fromtimestamp(value["updated_at"])
-            if "updated_at" in value
-            else ApiOmitted(),
-            created_by=value["created_by"] if "created_by" in value else ApiOmitted(),
+            created_at=(
+                dt.datetime.fromtimestamp(value["created_at"])
+                if value.get("created_at") is not None
+                else ApiOmitted()
+            ),
+            updated_at=(
+                dt.datetime.fromtimestamp(value["updated_at"])
+                if value.get("updated_at") is not None
+                else ApiOmitted()
+            ),
+            created_by=(
+                value["created_by"]
+                if value.get("created_by") is not None
+                else ApiOmitted()
+            ),
         )
 
 


### PR DESCRIPTION
## General information

DCD is crashing in Checkmk 2.5 if there are Hosts with following meta_data:
`"meta_data": {
 "created_at": null,
 "updated_at": "2026-06-08T08:39:43.296016+00:00",
 "created_by": null
 }
 },`

This case is happening with hosts created directly with hosts.mk or hosts older than Checkmk 1.6 (werk #7235)

## Bug reports

I tried this with Checkmk 2.5.0p3 pro.
All DCD connections are affected (Piggyback and FileConnector tested)
For more logs and informations see SUP-29418


## Proposed changes

Target of the fix is to prevent making a timestamp from a not existing value.
There should be no other impact.