### PR TITLE
capture sendmail output

### DIFF
--- a/cmk/utils/mail.py
+++ b/cmk/utils/mail.py
@@ -111,10 +111,10 @@ def send_mail_sendmail(m: Message, target: MailString, from_address: MailString 
         target = MailString(",".join(list(filter(None, target.split(",")))))
     cmd += ["-i", target]
 
-    completed_process = subprocess.run(cmd, encoding="utf-8", check=False, input=m.as_string())
+    completed_process = subprocess.run(cmd, encoding="utf-8", check=False, input=m.as_string(), capture_output=True)
 
     if completed_process.returncode:
-        raise RuntimeError("sendmail returned with exit code: %d" % completed_process.returncode)
+        raise RuntimeError("sendmail returned with exit code: %d; %s; %s" % (completed_process.returncode, completed_process.stderr, completed_process.stdout))
 
 
 # duplicate from omdlib


### PR DESCRIPTION
Seen with checkmk 2.4.0p24 in appliance 1.7.17

When there is an error with sending an email, the return code of sendmail is captured, but no further diagnostics.
In my example, a reporting background job failed (due to a postfix missconfiguration) with this terse message in the logs and in the gui:

`Scheduling report in background failed:`

With nothing after the colon.

Expected behaviour: Error messages from sendmail should propagate into logs and gui.

As one part of the fix, I suggest to capture stderr and stdout of sendmail.
This enables other parts of the code to pick up error messages and show them appropriately.
