### PR TITLE
agents: fix rare broken pipe warning in stat version detection

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -812,7 +812,7 @@ section_nfs_mounts() {
     proc_mounts_file=${1}
 
     if inpath waitmax; then
-        STAT_VERSION=$(stat --version | head -1 | cut -d" " -f4)
+        STAT_VERSION=$(stat --version 2>/dev/null | head -1 | cut -d" " -f4)
         STAT_BROKE="5.3.0"
 
         json_templ() {

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -490,7 +490,7 @@ section_mounts() {
     # call statfs()). If this lasts more then 2 seconds we
     # consider it as hanging. We need waitmax.
     if inpath waitmax; then
-        STAT_VERSION=$(stat --version | head -1 | cut -d" " -f4)
+        STAT_VERSION=$(stat --version 2>/dev/null | head -1 | cut -d" " -f4)
         STAT_BROKE="5.3.0"
 
         echo '<<<nfsmounts>>>'


### PR DESCRIPTION
## General information

OpenWrt-based device running the Checkmk agent. Affects the version detection logic `stat --version`.
 `stat` is provided by the `coreutils-stat` package (GNU coreutils), not busybox built-in `stat`.

## Bug reports

- OS: OpenWrt (coreutils-stat - 9.11)
- The agent occasionally emits a spurious stderr message, when calling section_mounts in check_mk_agent.openwrt:
    `stat: write error: Broken pipe`

- Steps to reproduce: run `stat --version | head -1 | cut -d" " -f4` in a loop. The error appears occasionally (more frequently on low-performance targets).

## Proposed changes

- Expected behavior: version detection runs silently, no stderr output.
- Observed behavior: `head -1` closes its end of the pipe after reading the first line. If `stat --version` hasn't finished writing all its output yet, this causes a write to a closed pipe (EPIPE), which coreutils reports as "write error: Broken pipe" on stderr. The parsed version value itself is unaffected, only the stderr message is noisy.
- Fix: redirect stderr to /dev/null for this call, suppressing the spurious warning.
