### PR TITLE
hp_proliant_da_cntlr: do not discover phantom controllers

### DIFF
--- a/cmk/plugins/hp_proliant/agent_based/hp_proliant_da_cntlr.py
+++ b/cmk/plugins/hp_proliant/agent_based/hp_proliant_da_cntlr.py
@@ -187,8 +187,9 @@ def parse_hp_proliant_da_cntlr(string_table: StringTable) -> ParsedSection:
 
 
 def discovery_hp_proliant_da_cntlr(section: ParsedSection) -> DiscoveryResult:
-    if section:
-        yield from (Service(item=item) for item in section)
+    # Skip phantom placeholder rows (all-zero cells, parsed to ``None``): they
+    # are not real controllers and would produce a permanently UNKNOWN service.
+    yield from (Service(item=item) for item, data in section.items() if data is not None)
 
 
 def check_hp_proliant_da_cntlr(item: ControllerID, section: ParsedSection) -> CheckResult:

--- a/tests/unit/cmk/plugins/hp_proliant/agent_based/test_hp_proliant_da_cntlr.py
+++ b/tests/unit/cmk/plugins/hp_proliant/agent_based/test_hp_proliant_da_cntlr.py
@@ -27,7 +27,6 @@ def test_discovery() -> None:
         Service(item="0"),
         Service(item="3"),
         Service(item="6"),
-        Service(item="9"),
     ]
 
 


### PR DESCRIPTION
## What

`hp_proliant_da_cntlr` no longer discovers phantom controllers.

## Why

On HPE ProLiant **Gen11 / iLO 6** the controller table (`cpqDaCntlrTable`) contains a placeholder row — typically index 0 — whose condition/role/board‑status/board‑condition cells are all `0` (a value the vendor MIB does not define). `parse_hp_proliant_da_cntlr` already parses such rows to `None`, but `discovery_hp_proliant_da_cntlr` iterated over **all** section keys and still discovered the phantom item, whose service was then permanently `UNKNOWN` ("Controller not found in SNMP data").
