### PR TITLE
Fix crash when editing rules with hyphenated predefined condition IDs

### DIFF
--- a/.werks/20201.md
+++ b/.werks/20201.md
@@ -1,0 +1,21 @@
+[//]: # (werk v3)
+# Fix crash when editing rules with predefined conditions whose ID contains hyphens
+
+key        | value
+---------- | ---
+date       | 2026-07-13T00:00:00+00:00
+version    | 3.0.0b1
+class      | fix
+edition    | community
+component  | wato
+level      | 1
+compatible | yes
+
+Previously, opening or editing a rule that referenced a predefined condition whose unique ID
+contained a hyphen (e.g. `cond_host_monitoring-01`) caused a crash with the error:
+
+_ValueError: 'cond_host_monitoring-01' is not a valid, non-reserved Python identifier_
+
+This affected predefined conditions created in Checkmk 2.4 or earlier that used hyphens in
+their ID. The issue only appeared in the rule editor — the conditions themselves still matched
+correctly at runtime.

--- a/cmk/gui/watolib/rulesets.py
+++ b/cmk/gui/watolib/rulesets.py
@@ -2452,10 +2452,10 @@ def _create_rule_conditions_catalog_topic(
                             CascadingSingleChoiceElementAPI(
                                 name="predefined",
                                 title=Title("Predefined conditions"),
-                                parameter_form=SingleChoiceAPI(
+                                parameter_form=SingleChoiceExtendedAPI(
                                     title=Title("Predefined condition"),
                                     elements=[
-                                        SingleChoiceElementAPI(
+                                        SingleChoiceElementExtendedAPI(
                                             name=n, title=Title("%(title)s") % {"title": t}
                                         )
                                         for n, t in PredefinedConditionStore().choices()


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/Checkmk/checkmk#want-to-contribute) regarding process details.

## General information

Predefined condition identifiers created in Checkmk 2.4 or earlier could contain hyphens (e.g. 'cond_host_monitoring-01'). The new rule catalog renderer passed these idents directly as SingleChoiceElement names, which requires valid Python identifiers, causing a ValueError when opening or editing any rule that referenced such a condition.

Fix by using SingleChoiceExtended / SingleChoiceElementExtended (internal API) instead of the public SingleChoice / SingleChoiceElement for the predefined conditions list. The Extended variants do not validate names as Python identifiers.

## Bug reports

See https://forum.checkmk.com/t/unable-to-edit-rules-when-explicit-hostname-contains-hyphens/59918

## Proposed changes

Same fix than in https://github.com/Checkmk/checkmk/commit/9d1fe1a9df552c01448a708aa05b01a8b49f409e
Disclaimer: AI generated and untested.