### PR TITLE
Fix: Map missing WARNING-state

### DIFF
--- a/cmk/plugins/sap_hana/agent_based/sap_hana_diskusage.py
+++ b/cmk/plugins/sap_hana/agent_based/sap_hana_diskusage.py
@@ -78,7 +78,7 @@ def check_sap_hana_diskusage(
     elif state_name == "UNKNOWN":
         state = State.UNKNOWN
     elif state_name == "WARNING":
-        state = State.WARN        
+        state = State.WARN
     else:
         state = State.CRIT
     yield Result(state=state, summary="Status: %s" % state_name)

--- a/cmk/plugins/sap_hana/agent_based/sap_hana_diskusage.py
+++ b/cmk/plugins/sap_hana/agent_based/sap_hana_diskusage.py
@@ -71,11 +71,14 @@ def check_sap_hana_diskusage(
     if not data:
         raise IgnoreResultsError("Login into database failed.")
 
+    # Possible states: OK, WARNING, ERROR
     state_name = data["state_name"]
     if state_name == "OK":
         state = State.OK
     elif state_name == "UNKNOWN":
         state = State.UNKNOWN
+    elif state_name == "WARNING":
+        state = State.WARN        
     else:
         state = State.CRIT
     yield Result(state=state, summary="Status: %s" % state_name)


### PR DESCRIPTION
## General information

Then SAP-Hana disk-usage-checks did not map the SAP-WARNING state to CMK-Warn.
As result SAP-WARN lead to a CRIT-Ticket. This lead to creation of non-necessary on-call tickets.

## Bug reports

This  was observed in  CMK 2.3 already and the behaviour was not changed since then.

This available states delivered by the database-query are provided are documented here:

https://github.com/SAP-archive/sap-hana-cloud-hana-database/blob/main/docs/sql-ref/020-System-Views-Reference/022-Monitoring-Views/m-system-overview-system-view-20c61f0.md

Note: I did not change then "UNKNOWN"-mapping although it is not documented, since it does not harm 
and may have been seen on other/older SAP-setups.

