### PR TITLE
mysql: find sockets on default mariadb installation on Debian

### DIFF
--- a/agents/plugins/mk_mysql
+++ b/agents/plugins/mk_mysql
@@ -79,6 +79,9 @@ if [ -z "$mysql_socket_string" ]; then
     mysql_socket_string=$(ps -fww -C mysqld | grep "socket" | sed -ne 's/.*socket=\([^ ]*\).*/\1/p')
 fi
 if [ -z "$mysql_socket_string" ]; then
+    mysql_socket_string=$(find /run/mysqld -type s)
+fi
+if [ -z "$mysql_socket_string" ]; then
     do_query "" ""
 else
     IFS=" " mapfile -t mysql_sockets <<<"$mysql_socket_string"


### PR DESCRIPTION
## General information

The current auto-detect command doesn't work on a default MariaDB installation on Debian for two reasons:

- The account is called mariadbd
- No "socket" is in the CMD printed by ps



## Bug reports

No output of the current auto-detect code:

```
[root@mariadb ~]# ps -fww -C mysqld | grep "socket"
[root@mariadb ~]# ps -fww -C mariadbd | grep "socket"
[root@mariadb ~]#
```

## Proposed changes

As the default socket is `/run/mysqld/mysqld.sock`, use all sockets in `/run/mysqld` to support multi-instance setups.

From new Debian installation:

```
root@ca9b0a452ef5:/# grep socket -Ri /etc/mysql/
/etc/mysql/my.cnf:# Port or socket location where to connect
/etc/mysql/my.cnf:socket = /run/mysqld/mysqld.sock
/etc/mysql/my.cnf.fallback:# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
/etc/mysql/debian.cnf:# anyway thanks to unix socket authentication and hence
/etc/mysql/mariadb.cnf:# Port or socket location where to connect
/etc/mysql/mariadb.cnf:socket = /run/mysqld/mysqld.sock
```
