### PR TITLE
 mk_sap: apply host_prefix to logwatch piggyback 

### DIFF
--- a/cmk/plugins/sap/agents/mk_sap.py
+++ b/cmk/plugins/sap/agents/mk_sap.py
@@ -504,7 +504,7 @@ def check(pyrfc, cfg_entry):
     sys.stdout.write("<<<<>>>>\n")
 
     for host, host_logs in logs.items():
-        sys.stdout.write("<<<<%s>>>>\n" % host)
+        sys.stdout.write("<<<<%s%s>>>>\n" % (cfg_entry.get("host_prefix", ""), host))
         sys.stdout.write("<<<logwatch>>>\n")
         for log, lines in host_logs.items():
             sys.stdout.write("[[[%s]]]\n" % log)


### PR DESCRIPTION
## General information

Affected plugin: `agents/plugins/mk_sap.py` — the SAP R/3 agent plugin that
collects CCMS data via RFC (pyrfc) and emits it as piggyback blocks keyed by the
SAP System ID (SID). The `host_prefix` option prepends a string to the piggyback
host name.

This is a platform-independent issue (a Python string-formatting inconsistency);
it was observed on SLES 15 SP7 with pyrfc and NW RFC SDK 7.50, but does not depend
on the OS.

## Bug report

- Operating system: SLES 15 SP7 (issue is OS-independent)
- Local setup: two SAP systems sharing the same SID (an ECC and an S/4HANA system).
  `host_prefix` is used to give each source's piggyback data a distinct host name.
- Steps to reproduce:
  1. Set `host_prefix` in `/etc/check_mk/sap.cfg`, e.g. `"host_prefix": "S4H_"`.
  2. Run the plugin so that it produces both a `<<<sap>>>` section and a
     `<<<logwatch>>>` section (i.e. at least one MTE_MSG_CONTAINER with alerts).
  3. Inspect the emitted piggyback headers.

- Agent output (illustrative, with `host_prefix = "S4H_"`):

  Observed (current behavior):

```
<<<<S4H_SB1>>>>
<<sap:sep(9)>>

<<<<>>>>
<<<<SB1>>>>            <-- logwatch header WITHOUT the prefix
<<<logwatch>>>
```

 The SAP section and the logwatch section end up on two different piggyback
  hosts (`S4H_SB1` vs. `SB1`).

## Proposed changes

- Expected behavior: with `host_prefix` set, both the `sap` section and the
  `logwatch` section are written under the same (prefixed) piggyback host.
- Observed behavior: only the SAP data header includes the prefix; the logwatch
  header omits it. In `check()`, the SAP block writes
  `"<<<<%s%s>>>>\n" % (cfg_entry.get("host_prefix", ""), host)` while the logwatch
  block writes `"<<<<%s>>>>\n" % host`, dropping the prefix.
- Change: apply the same `host_prefix` formatting to the logwatch header so both
  sections share one piggyback host.
- Is this a new problem? No — a longstanding inconsistency. It surfaces when
  `host_prefix` is used, which is the natural way to disambiguate systems that
  share a SID.
- Unit test: a test that runs the output stage with a non-empty `host_prefix` and
  asserts that both the `sap` and the `logwatch` piggyback headers carry the
  prefix would have failed before this fix.