### PR TITLE
Postfix

### DIFF
--- a/cmk/plugins/sap/agents/mk_sap.py
+++ b/cmk/plugins/sap/agents/mk_sap.py
@@ -498,13 +498,19 @@ def check(pyrfc, cfg_entry):
                 )
 
     for host, host_sap in sap_data.items():
-        sys.stdout.write("<<<<%s%s>>>>\n" % (cfg_entry.get("host_prefix", ""), host))
+        sys.stdout.write(
+            "<<<<%s%s%s>>>>\n"
+            % (cfg_entry.get("host_prefix", ""), host, cfg_entry.get("host_postfix", ""))
+        )
         sys.stdout.write("<<<sap:sep(9)>>>\n")
         sys.stdout.write("%s\n" % "\n".join(host_sap))
     sys.stdout.write("<<<<>>>>\n")
 
     for host, host_logs in logs.items():
-        sys.stdout.write("<<<<%s%s>>>>\n" % (cfg_entry.get("host_prefix", ""), host))
+        sys.stdout.write(
+            "<<<<%s%s%s>>>>\n"
+            % (cfg_entry.get("host_prefix", ""), host, cfg_entry.get("host_postfix", ""))
+        )
         sys.stdout.write("<<<logwatch>>>\n")
         for log, lines in host_logs.items():
             sys.stdout.write("[[[%s]]]\n" % log)

--- a/cmk/plugins/sap/agents/mk_sap.py
+++ b/cmk/plugins/sap/agents/mk_sap.py
@@ -504,7 +504,7 @@ def check(pyrfc, cfg_entry):
     sys.stdout.write("<<<<>>>>\n")
 
     for host, host_logs in logs.items():
-        sys.stdout.write("<<<<%s>>>>\n" % host)
+        sys.stdout.write("<<<<%s%s>>>>\n" % (cfg_entry.get("host_prefix", ""), host))
         sys.stdout.write("<<<logwatch>>>\n")
         for log, lines in host_logs.items():
             sys.stdout.write("[[[%s]]]\n" % log)


### PR DESCRIPTION
## General information

Affected plugin: `agents/plugins/mk_sap.py` (SAP R/3 monitoring via RFC/CCMS).
The plugin emits piggyback blocks keyed by the SAP SID. It already supports a
`host_prefix` option; this change adds a symmetric `host_postfix`.

> Depends on #937 . That PR fixes the logwatch header to honor
> `host_prefix`; this PR builds on the same two header lines. Please merge the
> prefix fix first.

## Proposed changes

- What it does: adds an optional `host_postfix` config key. If set, it is appended
  to the SID in the piggyback host name (mirroring the existing `host_prefix`).
  It is applied to both the `sap` and the `logwatch` section headers, so both stay
  on the same piggyback host.
- Motivation: when several systems share a SID (e.g. an ECC and an S/4HANA system
  both called `SB1`), their piggyback data must be routed to distinct hosts. A
  suffix (`SB1_S4H`, `SB1_ECC`) is often preferable to a prefix for grouping and
  sorting by SID. Doing this in the plugin avoids needing a per-source-host
  "Host name translation for piggybacked hosts" rule on the server side, and it
  also works when two systems are monitored from the same agent host (where a
  source-host-based translation rule cannot separate them).
- Change: the header is written as
  `"<<<<%s%s%s>>>>\n" % (cfg_entry.get("host_prefix", ""), host, cfg_entry.get("host_postfix", ""))`
  for both sections.
- Backward compatibility: `host_postfix` defaults to `""` via `.get()`, so existing
  configurations are unaffected. The new option is documented in the sample config.
- What made you submit this? Monitoring two SAP systems that share a SID from
  related agent hosts; a suffix-based naming scheme was needed for clean host
  naming.
- Unit test: a test that sets `host_postfix` (and optionally `host_prefix`) and
  asserts both the `sap` and `logwatch` headers render as `<prefix><SID><postfix>`.