### PR TITLE
Fix missing PSU checks SUP-30042

### DIFF
--- a/packages/cmk-plugins/cmk/plugins/netapp/agent_based/netapp_ontap_environment.py
+++ b/packages/cmk-plugins/cmk/plugins/netapp/agent_based/netapp_ontap_environment.py
@@ -141,7 +141,7 @@ check_plugin_netapp_ontap_environment = CheckPlugin(
     name="netapp_ontap_environment",
     service_name="PSU Controller %s",
     discovery_function=discover_netapp_ontap_environment(
-        lambda v: v.name.startswith("PSU") and v.name.endswith(" FAULT")
+        lambda v: v.name.startswith("PSU") and (v.sensor_type == "fru")
     ),
     check_function=check_netapp_ontap_environment_discrete,
     check_ruleset_name="hw_psu",

--- a/packages/cmk-plugins/cmk/plugins/netapp/models.py
+++ b/packages/cmk-plugins/cmk/plugins/netapp/models.py
@@ -660,7 +660,7 @@ class EnvironmentThresholdSensorModel(EnvironmentSensorModel):
 
 
 class EnvironmentDiscreteSensorModel(EnvironmentSensorModel):
-    sensor_type: Literal["discrete"]
+    sensor_type: Literal["discrete", "fru"]
     discrete_value: str | None = None
     discrete_state: SensorState
 

--- a/packages/cmk-plugins/cmk/plugins/netapp/special_agent/agent_netapp_ontap.py
+++ b/packages/cmk-plugins/cmk/plugins/netapp/special_agent/agent_netapp_ontap.py
@@ -660,6 +660,7 @@ def fetch_psu(connection: HostConnection) -> Iterable[models.ShelfPsuModel]:
         "frus.id",
         "frus.state",
         "frus.installed",
+        "frus.type",
     )
 
     for element in NetAppResource.Shelf.get_collection(
@@ -670,6 +671,8 @@ def fetch_psu(connection: HostConnection) -> Iterable[models.ShelfPsuModel]:
         frus = element_data.get("frus", [])
 
         for fru in frus:
+            if fru.get("type") != "psu":
+                continue
             yield models.ShelfPsuModel(
                 list_id=list_id,
                 id=fru["id"],
@@ -924,7 +927,7 @@ def fetch_environment(connection: HostConnection) -> Iterable[models.Environment
         )
 
     for element in NetAppResource.Sensors.get_collection(
-        connection=connection, fields=",".join(field_query), type="discrete"
+        connection=connection, fields=",".join(field_query), type="discrete|fru"
     ):
         element_data = element.to_dict()
         yield models.EnvironmentDiscreteSensorModel(


### PR DESCRIPTION
We noticed, that the netapp_ontap_environment check does not discover controller power supplies for most netapp system types.

This is caused by sensor names that have changed.

Previously the discovery function only matched Sensors beginning with PSU and ending with FAULT. 
With this pull request this is changed to starting with PSU and is of sensor type fru.

Please be aware, that this might be an incompatible change, if the power supplies were discovered properly.
Also keep in mind, that we probably have the same issues with controller fans. Maybe you can consider that as well.

The netapp_ontap_psu check also had an issue. It discovered three power supplies, although there are actually two PSUs in a shelf. This is, because the ontap special agent iterates over all shelf frus returned by the api. This also includes the shelf modules. The shelf modules usually have the id 1 and 2. The PSUs have the ids 0 and 1.

This results in the following three services for each shelf.

Power Supply Shelf 0/0
Power Supply Shelf 0/1
Power Supply Shelf 0/2

It should only be 
Power Supply Shelf 0/0
Power Supply Shelf 0/1

This is also fixed by this PR