### PR TITLE
config path: robustly remove config serials with read-only dirs

### DIFF
--- a/packages/cmk-ccc/cmk/ccc/config_path.py
+++ b/packages/cmk-ccc/cmk/ccc/config_path.py
@@ -93,6 +93,27 @@ def _increment_to_next_serial(base: Path) -> int:
     return new_serial
 
 
+def _rmtree_robust(path: Path) -> None:
+    """Remove a tree even if directory write permissions were removed externally.
+
+    Some deployments strip write permissions from the distributed site tree.
+    On POSIX, only the permissions of the *directories* matter for deletion,
+    so restore them and retry.
+    """
+    try:
+        shutil.rmtree(path)
+    except PermissionError:
+        path.chmod(0o700)
+        for dirpath, dirnames, _filenames in path.walk():
+            for dirname in dirnames:
+                subdir = dirpath / dirname
+                # Don't follow symlinks: we must not change permissions
+                # outside the tree.  The symlink itself is simply unlinked.
+                if not subdir.is_symlink():
+                    subdir.chmod(0o700)
+        shutil.rmtree(path)
+
+
 def cleanup_old_configs(base: Path) -> None:
     root = VersionedConfigPath.make_root_path(base)
     if not root.exists():
@@ -123,7 +144,7 @@ def cleanup_old_configs(base: Path) -> None:
             count_kept_serials += 1
             continue
 
-        shutil.rmtree(serial.path)
+        _rmtree_robust(serial.path)
 
 
 @contextmanager
@@ -138,7 +159,7 @@ def create(base: Path) -> Iterator[ConfigCreationContext]:
 
     with suppress(FileNotFoundError):
         # this should not exist, but we must be robust.
-        shutil.rmtree(under_construction_path)
+        _rmtree_robust(under_construction_path)
     under_construction_path.mkdir(parents=True, exist_ok=False)
 
     yield ConfigCreationContext(

--- a/packages/cmk-ccc/tests/test_config_path.py
+++ b/packages/cmk-ccc/tests/test_config_path.py
@@ -193,6 +193,30 @@ class TestCleanupOldConfigs:
         assert (root / "latest").is_symlink()
         assert (root / "serial.mk").exists()
 
+    def test_removal_of_readonly_serial(self, tmp_path: Path) -> None:
+        """Old serials must be removed even if they contain read-only directories.
+
+        The `local` snapshot inside a serial dir preserves the permissions of
+        `$OMD_ROOT/local`, which may be read-only (e.g. distributed setups).
+        """
+        root, _ = self._make_helper_config(tmp_path, serials=[1, 2, 3], latest_serial=3)
+        local = root / "1" / "local"
+        plugins = local / "lib" / "plugins"
+        plugins.mkdir(parents=True)
+        (plugins / "check").touch()
+        unreadable = local / "share"
+        unreadable.mkdir()
+        (unreadable / "file.mk").touch()
+        unreadable.chmod(0o000)
+        for directory in (plugins, local / "lib", local, root / "1"):
+            directory.chmod(0o555)
+
+        cleanup_old_configs(tmp_path)
+
+        assert not (root / "1").exists()
+        assert (root / "2").exists()
+        assert (root / "3").exists()
+
     def test_proper_sorting(self, tmp_path: Path) -> None:
         """Serial directories must be sorted numerically, not lexically."""
         root, _ = self._make_helper_config(tmp_path, serials=[1, 5, 7, 12, 23], latest_serial=23)


### PR DESCRIPTION
## General information

This does not concern a monitored device, but Checkmk's own config
activation. Affected is the helper config handling in
`packages/cmk-ccc/cmk/ccc/config_path.py`: on activation, a new config
serial is created under `var/check_mk/core/helper_config/<serial>/`
and outdated serials are removed by `cleanup_old_configs()`.

Since 2.5.0b1, each serial also contains a snapshot of `$OMD_ROOT/local`
(commit 106da943df8, "relay config: include a snapshot of the local
files"). The snapshot is created with `shutil.copytree`, which preserves
permission bits.

## Bug reports

- Operating system: RHEL8.10
- Checkmk 2.5.0p10; the site's `$OMD_ROOT/local` hierarchy is
  intentionally read-only (`a-w`), because it is distributed centrally
  to prevent accidental local changes. This setup worked fine up to and
  including Checkmk 2.4.
- Steps to reproduce:
  1. `chmod -R a-w "$OMD_ROOT/local"`
  2. Activate changes (e.g. `cmk -O`) three times.
  3. The third activation crashes with
     `PermissionError: [Errno 13] Permission denied: '.../helper_config/1/local/...'`
     when `cleanup_old_configs()` tries to remove the oldest serial.
- No agent output / SNMP walk applicable.

## Proposed changes

- Expected behavior: outdated config serials are removed during config
  activation, regardless of the permissions of the snapshotted content.
- Observed behavior: `shutil.rmtree` raises `PermissionError`, because
  the `local/` snapshot inside the serial preserves the read-only
  permission bits and on POSIX a directory must be writable to unlink
  its children. This aborts the whole config activation.
- The patch changes removal to first try a plain `shutil.rmtree` (the
  common case stays unchanged) and, only on `PermissionError`, restore
  `0o700` on the directories of the serial's tree and retry. Each
  directory is fixed before it is first listed, so directories without
  read/execute permission are handled as well. Symlinks are skipped so
  no permissions outside the tree can be changed. The same robust
  removal is used for the stale under-construction serial in
  `create()`, which has the same failure mode.
- A unit test is included (`test_removal_of_readonly_serial`) that
  fails with `PermissionError` without the fix.
- This is a new problem in 2.5: in 2.4 the serial directories only
  contained files created by the site itself and were therefore always
  writable. The `local/` snapshot introduced in 2.5.0b1 brings
  externally controlled permissions into the serial directories for
  the first time.