### PR TITLE
Fix: comment field missing for host notification results in log views

### DIFF
--- a/cmk/gui/painter/v0/painters.py
+++ b/cmk/gui/painter/v0/painters.py
@@ -5835,6 +5835,19 @@ class PainterLogOptions(Painter):
         return ("", row["log_options"])
 
 
+def _log_comment_min_fields(log_type: str) -> int:
+    """Minimum number of ";"-separated fields in a notification log line
+    before a trailing comment field is present.
+
+    Host notification log lines have one field fewer than service
+    notification log lines (they lack the ";<service>" segment), so the
+    threshold below which no comment field can be present differs between
+    the two. See cmk.events.log_to_history._format_notification_message,
+    which is the counterpart producing these log lines.
+    """
+    return 6 if "SERVICE" in log_type else 5
+
+
 class PainterLogComment(Painter):
     @property
     @override
@@ -5852,14 +5865,14 @@ class PainterLogComment(Painter):
     @property
     @override
     def columns(self) -> Sequence[ColumnName]:
-        return ["log_options"]
+        return ["log_options", "log_type"]
 
     @override
     def render(self, row: Row, cell: Cell, user: LoggedInUser) -> CellSpec:
         msg = row["log_options"]
         if ";" in msg:
             parts = msg.split(";")
-            if len(parts) > 6:
+            if len(parts) > _log_comment_min_fields(row.get("log_type", "")):
                 return ("", parts[-1])
         return ("", "")
 

--- a/tests/unit/cmk/gui/plugins/views/test_painters.py
+++ b/tests/unit/cmk/gui/plugins/views/test_painters.py
@@ -23,7 +23,7 @@ from cmk.gui.config import active_config
 from cmk.gui.http import request
 from cmk.gui.logged_in import user
 from cmk.gui.painter.v0 import all_painters
-from cmk.gui.painter.v0.painters import _paint_custom_notes
+from cmk.gui.painter.v0.painters import _log_comment_min_fields, _paint_custom_notes
 from cmk.gui.type_defs import ColumnSpec, DynamicIconName, Row
 from cmk.gui.utils.html import HTML
 from cmk.gui.utils.roles import UserPermissions
@@ -1655,3 +1655,47 @@ def test_paint_custom_notes_file_inclusion_and_html_tags(
     expected_string = str(HTML.without_escaping("<hr>".join(expected_notes)))
 
     assert expected_string == notes_as_string
+
+
+@pytest.mark.parametrize(
+    "log_type, log_options, expected_comment",
+    [
+        # Host notification log lines have no ";<service>" segment, so with
+        # a comment present they only ever reach 6 fields, not 7.
+        pytest.param(
+            "HOST NOTIFICATION RESULT",
+            "cmkadmin;myhost;CRITICAL;my_plugin;some output;the comment",
+            "the comment",
+            id="host-with-comment",
+        ),
+        pytest.param(
+            "HOST NOTIFICATION RESULT",
+            "cmkadmin;myhost;CRITICAL;my_plugin;some output",
+            "",
+            id="host-without-comment",
+        ),
+        pytest.param(
+            "SERVICE NOTIFICATION RESULT",
+            "cmkadmin;myhost;My Service;CRITICAL;my_plugin;some output;the comment",
+            "the comment",
+            id="service-with-comment",
+        ),
+        pytest.param(
+            "SERVICE NOTIFICATION RESULT",
+            "cmkadmin;myhost;My Service;CRITICAL;my_plugin;some output",
+            "",
+            id="service-without-comment",
+        ),
+    ],
+)
+def test_log_comment_field_count(
+    log_type: str, log_options: str, expected_comment: str
+) -> None:
+    # Regression test for the comment field being silently dropped for host
+    # notifications: PainterLogComment.render used a hardcoded threshold of
+    # 6 fields that only matches the (one field longer) service notification
+    # log line layout.
+    parts = log_options.split(";")
+    min_fields = _log_comment_min_fields(log_type)
+    actual_comment = parts[-1] if len(parts) > min_fields else ""
+    assert actual_comment == expected_comment


### PR DESCRIPTION
## Summary

- `PainterLogComment.render()` (`cmk/gui/painter/v0/painters.py`) decides whether a notification log line carries a trailing comment by checking `len(parts) > 6` on the `;`-split `log_options` string.
- That threshold only matches the layout of **service** notification log lines, which carry an extra `;<service>` segment (`contact;host;service;state;plugin;output;comment` = 7 fields with a comment).
- **Host** notification log lines lack that segment (`contact;host;state;plugin;output;comment` = only 6 fields, even with a comment present), so they can never cross the `> 6` bar.
- Net effect: the "Comment" column in notification log views (e.g. WATO → Notifications → Analyse, or any GUI view/log table using the `log_comment` painter) is **silently empty for every host notification**, regardless of what the notification plugin wrote to stdout. Service notifications are unaffected.
- Confirmed against the log-line producer, `cmk.events.log_to_history._format_notification_message`, which explicitly builds `spec` differently for host (`spec = hostname`) vs. service (`spec = f"{hostname};{service}"`) — this is the source of the one-field difference.

## Fix

Extracted the threshold into a small helper, `_log_comment_min_fields(log_type)`, returning `6` for service log types and `5` for host log types (`> 5` for host is the layout-correct equivalent of the old `> 6` for service). `PainterLogComment` now also requests the `log_type` column (already used by the neighboring `PainterLogPluginOutput`) to tell host and service log lines apart.

## Test plan

- Added `test_log_comment_field_count` in `tests/unit/cmk/gui/plugins/views/test_painters.py`, parametrized over host/service × with/without comment, exercising the field-count logic directly.
- `python -m py_compile` on both changed files.
- Not run: full `pytest`/`mypy` (no local Bazel/hatch dev environment available in the sandbox this was authored in) — please let CI confirm.