### PR TITLE
add vm_ip to labels of azure vms

### DIFF
--- a/packages/cmk-plugins/cmk/plugins/azure_v2/special_agent/agent_azure_v2.py
+++ b/packages/cmk-plugins/cmk/plugins/azure_v2/special_agent/agent_azure_v2.py
@@ -2401,9 +2401,9 @@ async def _collect_virtual_machines_resources(
         except KeyError:
             raise ApiErrorMissingData("Virtual machine instance's statuses must be present")
 
-        ip = vm_ip_map.get(vm["id"].lower())
-        if ip is not None:
-            resource.labels["vm_ip"] = ip
+        vm_ip = vm_ip_map.get(vm["id"].lower())
+        if vm_ip is not None:
+            resource.labels["vm_ip"] = vm_ip
 
         resource.info["specific_info"] = {"statuses": statuses}
         # for backward compatibility

--- a/packages/cmk-plugins/cmk/plugins/azure_v2/special_agent/agent_azure_v2.py
+++ b/packages/cmk-plugins/cmk/plugins/azure_v2/special_agent/agent_azure_v2.py
@@ -2368,6 +2368,24 @@ async def _collect_virtual_machines_resources(
         key="value",
     )
 
+    nics = await api_client.get_async(
+            "providers/Microsoft.Network/networkInterfaces",
+            params={"api-version": "2024-07-01"},
+            key="value",
+        )
+    vm_ip_map: dict[str, str] = {}
+        
+    for nic in nics:
+        try:
+            vm_name = nic["properties"]["virtualMachine"]["id"].lower()
+
+            private_ip = (
+                nic["properties"]["ipConfigurations"][0]["properties"]["privateIPAddress"]
+            )
+            vm_ip_map[vm_name] = private_ip
+        except (KeyError, IndexError):
+            continue
+
     virtual_machines: list[AzureResource] = []
     for vm in response:
         try:
@@ -2384,6 +2402,13 @@ async def _collect_virtual_machines_resources(
             statuses = vm.pop("properties")["instanceView"]["statuses"]
         except KeyError:
             raise ApiErrorMissingData("Virtual machine instance's statuses must be present")
+
+        try:
+            resource.labels["vm_ip"] = vm_ip_map.get(vm["id"].lower())
+        except KeyError:
+            LOGGER.info(
+                "Virtual machine not found in ip mapping: %(vm_id)s", {"vm_id": vm["id"]}
+            )
 
         resource.info["specific_info"] = {"statuses": statuses}
         # for backward compatibility

--- a/packages/cmk-plugins/cmk/plugins/azure_v2/special_agent/agent_azure_v2.py
+++ b/packages/cmk-plugins/cmk/plugins/azure_v2/special_agent/agent_azure_v2.py
@@ -2369,19 +2369,17 @@ async def _collect_virtual_machines_resources(
     )
 
     nics = await api_client.get_async(
-            "providers/Microsoft.Network/networkInterfaces",
-            params={"api-version": "2024-07-01"},
-            key="value",
-        )
+        "providers/Microsoft.Network/networkInterfaces",
+        params={"api-version": "2024-07-01"},
+        key="value",
+    )
+
     vm_ip_map: dict[str, str] = {}
-        
     for nic in nics:
         try:
             vm_name = nic["properties"]["virtualMachine"]["id"].lower()
 
-            private_ip = (
-                nic["properties"]["ipConfigurations"][0]["properties"]["privateIPAddress"]
-            )
+            private_ip = nic["properties"]["ipConfigurations"][0]["properties"]["privateIPAddress"]
             vm_ip_map[vm_name] = private_ip
         except (KeyError, IndexError):
             continue
@@ -2403,12 +2401,9 @@ async def _collect_virtual_machines_resources(
         except KeyError:
             raise ApiErrorMissingData("Virtual machine instance's statuses must be present")
 
-        try:
-            resource.labels["vm_ip"] = vm_ip_map.get(vm["id"].lower())
-        except KeyError:
-            LOGGER.info(
-                "Virtual machine not found in ip mapping: %(vm_id)s", {"vm_id": vm["id"]}
-            )
+        ip = vm_ip_map.get(vm["id"].lower())
+        if ip is not None:
+            resource.labels["vm_ip"] = ip
 
         resource.info["specific_info"] = {"statuses": statuses}
         # for backward compatibility


### PR DESCRIPTION
General information

This change makes it possible to receive the ip of azure vms as label for the vms.

Proposed changes

The behavior of the Special Agent call remains unchanged. Only one additional endpoints in the vm function will be called and mapped.
No ruleset or agent_based changes.
