### PR TITLE
Update apc_symmetra.py

### DIFF
--- a/cmk/plugins/apc/agent_based/apc_symmetra.py
+++ b/cmk/plugins/apc/agent_based/apc_symmetra.py
@@ -292,7 +292,7 @@ def check_apc_symmetra(params: CheckParameters, section: ParsedSection) -> Check
         )
 
     if battery_capacity:
-        if alt_crit_capacity is not None and diff_sec < allowed_delay_sec and calib_result is 3:
+        if alt_crit_capacity is not None and diff_sec < allowed_delay_sec and calib_result == "3":
             yield from check_levels(
                 value=battery_capacity,
                 levels_lower=("fixed", (alt_crit_capacity, alt_crit_capacity)),

--- a/cmk/plugins/apc/agent_based/apc_symmetra.py
+++ b/cmk/plugins/apc/agent_based/apc_symmetra.py
@@ -296,16 +296,20 @@ def check_apc_symmetra(params: CheckParameters, section: ParsedSection) -> Check
             yield from check_levels(
                 value=battery_capacity,
                 levels_lower=("fixed", (alt_crit_capacity, alt_crit_capacity)),
-                label="delay after calibration",
+                metric_name="capacity",
+                render_func=render.percent,
+                boundaries=(0, 100),
+                label="Capacity during/after calibration",
             )
-        yield from check_levels(
-            value=battery_capacity,
-            levels_lower=params["capacity"],
-            metric_name="capacity",
-            render_func=render.percent,
-            boundaries=(0, 100),
-            label="Capacity",
-        )
+        else:
+            yield from check_levels(
+                value=battery_capacity,
+                levels_lower=params["capacity"],
+                metric_name="capacity",
+                render_func=render.percent,
+                boundaries=(0, 100),
+                label="Capacity",
+            )
 
     if battery_time_remain:
         battery_time_remain = battery_time_remain / 100.0

--- a/cmk/plugins/apc/agent_based/apc_symmetra.py
+++ b/cmk/plugins/apc/agent_based/apc_symmetra.py
@@ -292,7 +292,7 @@ def check_apc_symmetra(params: CheckParameters, section: ParsedSection) -> Check
         )
 
     if battery_capacity:
-        if alt_crit_capacity is not None and diff_sec < allowed_delay_sec:
+        if alt_crit_capacity is not None and diff_sec < allowed_delay_sec and calib_result is 3:
             yield from check_levels(
                 value=battery_capacity,
                 levels_lower=("fixed", (alt_crit_capacity, alt_crit_capacity)),


### PR DESCRIPTION
The alternate level would be overwritten by the regular levels and not taken into account at all, and what was labelled as the delay would rather report the (ignored) alternate level. This fixes both issues.