### PR TITLE
Patched resolve_secret_option password_store API function to handle multiword arguments properly

### DIFF
--- a/packages/cmk-plugin-apis/cmk/password_store/v1_unstable/_convenience.py
+++ b/packages/cmk-plugin-apis/cmk/password_store/v1_unstable/_convenience.py
@@ -105,6 +105,7 @@ def resolve_secret_option(args: argparse.Namespace, option_name: str) -> Secret[
 
 
     """
+    option_name = option_name.replace("-", "_")
     if (secret_id := getattr(args, f"{option_name}_id", None)) is not None:
         return dereference_secret(secret_id)
 


### PR DESCRIPTION
## General information
I encountered this issue when testing the new cmk.password_store.v1_unstable API that has been introduced with Checkmk 2.5.

## Bugreport
When using the `parser_add_secret_option` and `resolve_secret_option` functions from the `new cmk.password_store.v1_unstable` API with the `OPTION_NAME` variable consisting of at least two words, separated by a '-' (e.g. 'client-secret'), the resolve function would break and throw a TypeError Exception. This happens because argparser translates such arguments to be separated by a '_' ("--client-secret" translates to args.client_secret).

## Proposed changes
I fixed this with this small one-liner that before anything else replaces "-" by "_" in the option_name variable. The change does not break any behaviour, only fixes this small issue.


I already did a Pull Request for this (https://github.com/Checkmk/checkmk/pull/913), but some Pipelines failed and I lost track of it. So this is attempt #2 for this.