### PR TITLE
Added option to not discover MSSQL jobs with disabled scheduler

### DIFF
--- a/cmk/plugins/mssql/agent_based/mssql_jobs.py
+++ b/cmk/plugins/mssql/agent_based/mssql_jobs.py
@@ -195,9 +195,11 @@ def parse_mssql_jobs(string_table: StringTable) -> Mapping[str, JobSpec]:
     return section
 
 
-def discover_mssql_jobs(section: Mapping[str, JobSpec]) -> DiscoveryResult:
-    for job_name in section:
-        if job_name:
+def discover_mssql_jobs(params: dict[str, bool], section: Mapping[str, JobSpec]) -> DiscoveryResult:
+    for job_name, job_specs in section.items():
+        if not params.get("discover_schedule_disabled") and not job_specs.schedule_enabled:
+            continue
+        else:
             yield Service(item=job_name)
 
 
@@ -257,5 +259,9 @@ check_plugin_mssql_jobs = CheckPlugin(
         "status_disabled_jobs": 0,
         "status_disabled_schedule": 0,
         "status_missing_jobs": 2,
+    },
+    discovery_ruleset_name="mssql_jobs_discovery",
+    discovery_default_parameters={
+        "discover_schedule_disabled": True,
     },
 )

--- a/cmk/plugins/mssql/rulesets/mssql_jobs_discovery.py
+++ b/cmk/plugins/mssql/rulesets/mssql_jobs_discovery.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from cmk.rulesets.v1 import (
+    Label,
+    Title,
+)
+from cmk.rulesets.v1.form_specs import (
+    BooleanChoice,
+    DefaultValue,
+    DictElement,
+    Dictionary,
+)
+from cmk.rulesets.v1.rule_specs import (
+    DiscoveryParameters,
+    Topic,
+)
+
+
+def _parameter_form_mssql_jobs_discovery() -> Dictionary:
+    return Dictionary(
+        title=Title("MSSQL Jobs Discovery"),
+        elements={
+            "discover_schedule_disabled": DictElement(
+                parameter_form=BooleanChoice(
+                    label=Label("Discover jobs with disabled Scheduler"),
+                    prefill=DefaultValue(True),
+                ),
+                required=True,
+            ),
+        },
+    )
+
+
+rule_spec_mssql_jobs_discovery = DiscoveryParameters(
+    name="mssql_jobs_discovery",
+    title=Title("MSSQL Jobs Discovery"),
+    topic=Topic.APPLICATIONS,
+    parameter_form=_parameter_form_mssql_jobs_discovery,
+)


### PR DESCRIPTION
## General information
This introduces a new discovery rule that enables Checkmk administrators to deactivate the discovery of disabled mssql jobs.

## Proposed changes
Until now, Checkmk tries to discover all MSSQL jobs. But this is often not wanted, as there can be old / unused jobs where the scheduler is disabled. Until now the only option was to manually disable those services. So with this PR there comes a new discovery rule, that makes it possible to not discover those disabled jobs:
<img width="520" height="74" alt="image" src="https://github.com/user-attachments/assets/1f4147f3-9cc4-4e52-8680-72ea59cc8bd5" />

The default behaviour of the discovery stays unchanged, this new rule is completely optional.


I already did a Pull Request for this (https://github.com/Checkmk/checkmk/pull/910), but some Pipelines failed and I lost track of it. So this is the second attempt for this.