### PR TITLE
Fixed a bug in signl4 notification plugin that would crash the script if there are non-ascii characters in the service description

### DIFF
--- a/packages/cmk-notification-plugins/cmk/notification_plugins/signl4.py
+++ b/packages/cmk-notification-plugins/cmk/notification_plugins/signl4.py
@@ -52,7 +52,7 @@ def _signl4_msg(context: dict[str, str]) -> dict[str, object]:
     service_desc_base64 = ""
     service_desc_id_part = ""
     if len(service_desc) > 0:
-        service_desc_bytes = service_desc.encode("ascii")
+        service_desc_bytes = service_desc.encode("ascii", errors="replace")
         service_desc_base64 = base64.b64encode(service_desc_bytes).decode()
         service_desc_id_part = ":ServiceDesc:" + service_desc_base64
     return {


### PR DESCRIPTION
## General information
This fixes a small bug in the signl4 notification plugin, being caused by non-ascii characters in the service description of alerts.

## Bugreport
When a service alert triggers the signl4 notification plugin and this service contains non-ascii characters (e.g. umlauts), the notification plugin would crash.

## Proposed changes
I fixed this by defining the behaviour on errors within the `encode` function to replace those non-ascii characters with a "?". So now instead of crashing the service description will be slightly altered.
Example:
A service like "Log C:\temp\Domänen-Admins.log)" will now report via signl4 with the service description "Log C:\temp\Dom?nen-Admins.log".