### PR TITLE
Added host labels for the checkmk agents version

### DIFF
--- a/cmk/plugins/checkmk/agent_based/check_mk.py
+++ b/cmk/plugins/checkmk/agent_based/check_mk.py
@@ -88,8 +88,10 @@ def host_label_function_labels(section: CheckmkSection) -> HostLabelGenerator:
 
     if (agent_version := section.get("version")) is not None:
         yield HostLabel("cmk/agent_version", agent_version)
-        agent_major = re.match(r'[0-9.]+', agent_version)
-        yield HostLabel("cmk/agent_version_major", agent_major.group(0) if agent_major else agent_version)
+        agent_major = re.match(r"[0-9.]+", agent_version)
+        yield HostLabel(
+            "cmk/agent_version_major", agent_major.group(0) if agent_major else agent_version
+        )
 
 
 agent_section_check_mk = AgentSection(

--- a/cmk/plugins/checkmk/agent_based/check_mk.py
+++ b/cmk/plugins/checkmk/agent_based/check_mk.py
@@ -4,6 +4,8 @@
 # conditions defined in the file COPYING, which is part of this source code package.
 
 
+import re
+
 from cmk.agent_based.v2 import (
     AgentSection,
     Attributes,
@@ -83,6 +85,11 @@ def host_label_function_labels(section: CheckmkSection) -> HostLabelGenerator:
 
     if (osversion := section.get("osversion")) is not None:
         yield HostLabel("cmk/os_version", osversion)
+
+    if (agent_version := section.get("version")) is not None:
+        yield HostLabel("cmk/agent_version", agent_version)
+        agent_major = re.match(r'[0-9.]+', agent_version)
+        yield HostLabel("cmk/agent_version_major", agent_major.group(0) if agent_major else agent_version)
 
 
 agent_section_check_mk = AgentSection(


### PR DESCRIPTION
## General information
With this two new host labels are being introduced, to help with host filtering and matching:
```
cmk/agent_version
cmk/agent_version_major
```
<img width="670" height="49" alt="image" src="https://github.com/user-attachments/assets/a518a08e-8c72-4241-ad31-a5220308dee1" />

## Proposed changes
Until now, an agents version could only be found out with either the "Check_MK Agent" Service or the HW-/SW-Inventory. Both could be used for filtering in views, but especially if you want to match rules only on hosts that have a specific version this was simply not possible.
But with this PR, every host that has an installed Checkmk agent will discover those two host labels. One for the major version like "2.4.0" or "2.5.0" and one with the exact version like "2.5.0p11". One for broad filtering and one for exact filtering. This enables users to more easily filter in dashboards and views for specific agent versions and administrators to match rules only for specific agent versions, e.g. if you want to disable the "System Time" Service for all hosts, that already have a 2.5.0 Checkmk Agent, as with this there come the new "Windows time service" services.
