### PR TITLE
agent_aws: handle bytes values in special agent JSON serializer

### DIFF
--- a/packages/cmk-plugins/cmk/plugins/aws/special_agent/agent_aws.py
+++ b/packages/cmk-plugins/cmk/plugins/aws/special_agent/agent_aws.py
@@ -297,6 +297,9 @@ def datetime_serializer(obj):
     """Custom serializer to pass to json dump functions"""
     if isinstance(obj, datetime):
         return str(obj)
+    if isinstance(obj, bytes):
+        # e.g. WAFv2 ByteMatchStatement.SearchString is returned by boto3 as bytes
+        return obj.decode("utf-8", errors="replace")
     # fall back to json default behaviour:
     raise TypeError("%r is not JSON serializable" % obj)
 


### PR DESCRIPTION
## Summary

The AWS special agent's custom JSON serializer (`datetime_serializer` in `agent_aws.py`) only handles `datetime` objects and raises `TypeError` for anything else. AWS WAFv2's `ByteMatchStatement.SearchString` field is decoded by boto3 as Python `bytes` (e.g. `b'/admin/'` for a rule blocking that URI path), which is a completely ordinary WAFv2 rule configuration. When such a rule exists on a monitored Web ACL, serializing the `wafv2_web_acl` section raises an unhandled `TypeError`, and the special agent exits with code 1 before finishing output. This causes `Check_MK Discovery` to report the WAFv2 (and any other not-yet-emitted) services as vanished/critical, even though AWS connectivity and credentials are fine.

Reproduced with `--debug`:

```
TypeError: b'/admin/' is not JSON serializable
```

## Fix

Add a `bytes` branch to `datetime_serializer` that decodes to `str` (UTF-8, `errors="replace"`) instead of falling through to the `TypeError`.

## Test plan

- [x] Ran `agent_aws` manually against a WAFv2 Web ACL containing a `ByteMatchStatement` rule; reproduced `TypeError: b'...' is not JSON serializable` and exit code 1 on the unpatched agent
- [x] Applied the fix; reran the same invocation, got exit code 0 and a correctly decoded `SearchString` value in the `wafv2_web_acl` section
- [x] Re-enabled WAFv2 monitoring on the affected host and confirmed `Check_MK Discovery` and all AWS/WAFv2 services report OK