### PR TITLE
fix handling when tarinfo is None

### DIFF
--- a/omd/packages/omd/omdlib/backup.py
+++ b/omd/packages/omd/omdlib/backup.py
@@ -5,6 +5,9 @@
 
 """Cares about backing up the files of a site"""
 
+# mypy: disable-error-code="comparison-overlap"
+# mypy: disable-error-code="redundant-expr"
+
 import contextlib
 import errno
 import fnmatch
@@ -384,7 +387,7 @@ def _tar_add(
             # Create a TarInfo object from the file.
             tarinfo = _get_tar_info_or_raise(tar, name, arcname)
             # Exclude files.
-            if not predicate(tarinfo):
+            if tarinfo is None or not predicate(tarinfo):
                 return
 
             # Create a backup of history file and add it to the archive as history.sqlite.


### PR DESCRIPTION
For unsupported file types like Unix sockets and possibly other types, TarFile.getattrinfo() can return None. This commit reverts the changes from 77898dc7768fa8f5d696aecd031b6cfb022dd7fe to avoid crashes. (change I19d966fe510b994b0e5809cdc394d7e4e87a106d)

The problem happened at a customer so that "omd backup" failed with a traceback and no site backup was possible after a 2.5 update from 2.4. It could be fixed after we compared it to the 2.4 code and reverted the line to "if tarinfo is None or not predicate(tarinfo):", which is more robust in real life environments.

Kind regards, Dirk.

